### PR TITLE
Fix patch and PKGBUILD for freetype 2.8

### DIFF
--- a/01_freetype2-iu/0002-infinality-2.8-2017.05.24.patch
+++ b/01_freetype2-iu/0002-infinality-2.8-2017.05.24.patch
@@ -1,7 +1,7 @@
-From b0f880b8216e56ad48d4c3b59a0d565fcace8e12 Mon Sep 17 00:00:00 2001
+From 48c2930e9b83c47457ca03f5f8e6f1b61540a8e6 Mon Sep 17 00:00:00 2001
 From: "Devin J. Pohly" <djpohly@gmail.com>
-Date: Mon, 22 May 2017 12:39:32 -0500
-Subject: [PATCH] infinality 2.8 2017.05.22
+Date: Wed, 24 May 2017 15:08:52 -0500
+Subject: [PATCH] infinality 2.8 2017.05.24
 
 ---
  builds/freetype.mk                 |    1 +
@@ -13,8 +13,14 @@ Subject: [PATCH] infinality 2.8 2017.05.22
  src/autofit/afmodule.c             |    7 +
  src/base/Jamfile                   |    1 +
  src/base/ftbase.c                  |    3 +
+ src/base/ftinf.c                   |  363 +++++
+ src/base/ftinf.h                   |   66 +
+ src/base/ftinf_rh.c                |  626 ++++++++
+ src/base/ftinf_rh.gperf            |  283 ++++
+ src/base/ftinf_sh.c                |  463 ++++++
+ src/base/ftinf_sh.gperf            |  264 ++++
  src/base/ftinit.c                  |   14 +-
- src/base/ftlcdfil.c                |   36 +-
+ src/base/ftlcdfil.c                |   35 +-
  src/base/ftobjs.c                  |   67 +-
  src/base/ftoutln.c                 |   10 +-
  src/base/ftsynth.c                 |   22 +-
@@ -22,7 +28,13 @@ Subject: [PATCH] infinality 2.8 2017.05.22
  src/cff/cffobjs.c                  |    6 +
  src/smooth/ftsmooth.c              | 2808 ++++++++++++++++++++++++++++++++++--
  src/truetype/ttinterp.c            |    1 +
- 18 files changed, 3057 insertions(+), 122 deletions(-)
+ 24 files changed, 5122 insertions(+), 121 deletions(-)
+ create mode 100644 src/base/ftinf.c
+ create mode 100644 src/base/ftinf.h
+ create mode 100644 src/base/ftinf_rh.c
+ create mode 100644 src/base/ftinf_rh.gperf
+ create mode 100644 src/base/ftinf_sh.c
+ create mode 100644 src/base/ftinf_sh.gperf
 
 diff --git a/builds/freetype.mk b/builds/freetype.mk
 index f8cfd41..7e7ac5b 100644
@@ -467,6 +479,2107 @@ index 55f7359..4d50dca 100644
  
  
  /* END */
+diff --git a/src/base/ftinf.c b/src/base/ftinf.c
+new file mode 100644
+index 0000000..5d6b7f6
+--- /dev/null
++++ b/src/base/ftinf.c
+@@ -0,0 +1,363 @@
++#include <stdlib.h>
++#include "ftinf.h"
++#define true  1
++#define false 0
++
++#define on  1
++#define off 0
++#define end (-128)
++
++#define sw2pv 18  /* STEM_WIDTH_2_PPEM */
++#define maxp 100  /* MAX_PPEM */
++
++typedef signed char pv;         /* ppm and values type */
++/* the arrays start with existence flag + values */
++typedef struct sa_rules_s {
++    const char *name;
++    pv always_use_100[1+4+1];
++    pv brightness[1+2+1];
++    pv contrast[1+2+1];
++    pv edge_detection[1+4+1];
++    pv m[1+4+1];
++    pv bearing_correction[1+2+1];
++    pv spacing[1+5+1];
++    pv start[1+5+1];
++    pv stem_scaling[1+6+1];
++    pv stem_translating[1+2+1];
++    pv stem_translating_only[1+10+1];
++    pv stem_widths[1+4];        /* these end with maxp */
++    pv synthesize_stems[1+2+1];
++} sa_rules_t;
++
++#pragma GCC diagnostic ignored "-Wpedantic" /* C99 struct initializer tags are needed */
++#pragma GCC diagnostic ignored "-Wunused-function"
++
++const ftinf_t *ftinf;
++/* final settings, updated from environment */
++ftinf_t _env;
++
++/* rules and hashing function */
++#include "ftinf_rh.c"
++
++/* rules selection */
++void ftinf_fill_stem_values( Stem_Data *stem_values,
++                             const char *family, int ppem, int use_known ){
++    /* set the defaults */
++    stem_values->bearing_correction = TRUE;
++    stem_values->brightness = 0.0;
++    stem_values->contrast = 0.0;
++    stem_values->edge_detection = FALSE;
++    stem_values->m = -1;
++    stem_values->stem_scaling = -1;
++    stem_values->stem_spacing = -1;
++    stem_values->stem_start = -1;
++    stem_values->stem_translating = 0;
++    stem_values->stem_translating_only = -1024;
++    stem_values->stem_width = -1;
++    stem_values->synth_stems = FALSE;
++    stem_values->use_100 = FALSE;
++    /* pick from known rules if requested and they exist for current family */
++    if( !use_known )
++        return;
++    else {
++        const sa_rules_t *r=ftinf_rules( family );
++        int i;
++        if( r==NULL ) return;
++        if( r->stem_widths[0]==on )
++            for( i=1; r->stem_widths[i]!=maxp; ++i )
++                if( ppem < r->stem_widths[i] ){
++                    stem_values->stem_width = i-1;
++                    break;
++                }
++
++        if( r->stem_scaling[0]==on )
++            for( i=1; r->stem_scaling[i]!=end; i+=2 )
++                if( ppem==r->stem_scaling[i] ){
++                    stem_values->stem_scaling = r->stem_scaling[i+1];
++                    break;
++                }
++
++        if( r->m[0]==on )
++            for( i=1; r->m[i]!=end; i+=2 )
++                if( ppem==r->m[i] ){
++                    stem_values->m = r->m[i+1];
++                    break;
++                }
++
++        if( r->stem_translating_only[0]==on )
++            for( i=1; r->stem_translating_only[i]!=end; i+=2 )
++                if( ppem==r->stem_translating_only[i] || r->stem_translating_only[i]==0 ){
++                    stem_values->stem_translating_only = r->stem_translating_only[i+1];
++                    break;
++                }
++
++        if( r->stem_translating[0]==on )
++            for( i=1; r->stem_translating[i]!=end; i+=2 )
++                if( ppem==r->stem_translating[i] || r->stem_translating[i]==0 ){
++                    stem_values->stem_translating = r->stem_translating[i+1];
++                    break;
++                }
++
++        if( r->always_use_100[0]==on )
++            for( i=1; r->always_use_100[i]!=end; i+=2 )
++                if( ppem>=r->always_use_100[i] && ppem<=r->always_use_100[i+1] ){
++                    stem_values->use_100 = TRUE;
++                    break;
++                }
++
++        if( r->synthesize_stems[0]==on )
++            for( i=1; r->synthesize_stems[i]!=end; i+=2 )
++                if( ppem>=r->synthesize_stems[i] && ppem<=r->synthesize_stems[i+1] ){
++                    stem_values->synth_stems = TRUE;
++                    break;
++                }
++
++        if( r->edge_detection[0]==on )
++            for( i=1; r->edge_detection[i]!=end; i+=2 )
++                if( ppem>=r->edge_detection[i] && ppem<=r->edge_detection[i+1] ){
++                    stem_values->edge_detection = TRUE;
++                    break;
++                }
++
++        if( r->bearing_correction[0]==on )
++            for( i=1; r->bearing_correction[i]!=end; i+=2 )
++                if( ppem>=r->bearing_correction[i] && ppem<=r->bearing_correction[i+1] ){
++                    stem_values->bearing_correction = FALSE;
++                    break;
++                }
++
++#if(0)
++        if( r->brightness[0]==on )
++            for( i=1; r->brightness[i]!=end; i+=2 )
++                if( ppem==r->brightness[i]||r->brightness[i]==0 ){
++                    stem_values->brightness=r->brightness[i+1]*(1.0f/300.0f);
++                    break;
++                }
++
++        if( r->contrast[0]==on )
++            for( i=1; r->contrast[i]!=end; i+=2 )
++                if( ppem==r->contrast[i]||r->contrast[i]==0 ){
++                    stem_values->contrast=r->contrast[i+1]*(1.0f/300.0f);
++                    break;
++                }
++        if( r->spacing[0]==on ){
++            /* not used by original code */
++        }
++        if( r->start[0]==on ){
++            /* not used by original code */
++        }
++#endif
++    }
++    return;
++}
++
++void ftinf_get_bc( const char *family, int ppem, float *brightness, float *contrast ){
++    const sa_rules_t *r=ftinf_rules( family );
++    *brightness=0;
++    *contrast=0;
++    if( r ){
++        int i;
++        if( r->brightness[0]==on )
++            for( i=1; r->brightness[i]!=end; i+=2 )
++                if( ppem==r->brightness[i]||r->brightness[i]==0 ){
++                    *brightness=r->brightness[i+1]*(1.0f/300.0f);
++                    break;
++                }
++
++        if( r->contrast[0]==on )
++            for( i=1; r->contrast[i]!=end; i+=2 )
++                if( ppem==r->contrast[i]||r->contrast[i]==0 ){
++                    *contrast=r->contrast[i+1]*(1.0f/300.0f);
++                    break;
++                }
++    }
++    return;
++}
++
++static int
++bool_val( const char *s ){
++    if ( s != NULL )
++        return strcasecmp(s, "true") == 0
++            || strcasecmp(s, "1") == 0
++            || strcasecmp(s, "on") == 0
++            || strcasecmp(s, "yes") ==0;
++    else
++        return 0;
++}
++
++static int
++int_val( const char *s, int min, int max ){
++    int val;
++    sscanf ( s, "%d", &val );
++    if ( val > max )
++        val = max;
++    else if ( val < min )
++        val = min;
++    return val;
++}
++
++/* settings and hashing function */
++#include "ftinf_sh.c"
++
++/*
++  Get active Infinality settings
++ */
++void ftinf_env(){
++    const char *s;
++    ftinf=ftinf_settings( getenv( "INFINALITY_FT" ) );
++
++    if( ftinf==NULL ){
++        ftinf=ftinf_settings( "ultimate3" );
++        /* this should always succeed */
++#if(0)
++        if( ftinf==NULL ){
++            /* put an error here */
++            exit(-1);
++        }
++#endif
++    }
++    _env=ftinf[0];      /* copy as defaults */
++
++    /* check if custom environment values are set and update with them */
++    s=getenv( "INFINALITY_FT_AUTOHINT_INCREASE_GLYPH_HEIGHTS" );
++    if( s ) _env.autohint_increase_glyph_heights=bool_val( s );
++    s=getenv( "INFINALITY_FT_AUTOHINT_SNAP_STEM_HEIGHT" );
++    if( s ) _env.autohint_snap_stem_height=int_val( s, 0, 100 );
++    s=getenv( "INFINALITY_FT_USE_VARIOUS_TWEAKS" );
++    if( s ) _env.use_various_tweaks=bool_val( s );
++    s=getenv( "INFINALITY_FT_USE_KNOWN_SETTINGS_ON_SELECTED_FONTS" );
++    if( s ) _env.use_known_settings_on_selected_fonts=bool_val(s);
++#if(0)                          /* not used (naming error also) */
++    s=getenv( "INFINALITY_FT_AUTOHINT_MINIMUM_STEM_WIDTH" );
++    if( s ) _env.autohint_minimum_stem_height=int_val( s, 0, 100 );
++#endif
++    s=getenv( "INFINALITY_FT_STEM_SNAPPING_SLIDING_SCALE" );
++    if( s ) sscanf( s, "%d", &_env.stem_snapping_sliding_scale );
++    s=getenv( "INFINALITY_FT_STEM_ALIGNMENT_STRENGTH" );
++    if( s ) sscanf( s, "%d", &_env.stem_alignment_strength );
++    s=getenv( "INFINALITY_FT_STEM_DARKENING_AUTOFIT" );
++    if( s ) _env.stem_darkening_autofit=bool_val( s );
++    s=getenv( "INFINALITY_FT_STEM_DARKENING_CFF" );
++    if( s ) _env.stem_darkening_cff=bool_val( s );
++    s=getenv( "INFINALITY_FT_STEM_FITTING_STRENGTH" );
++    if( s ) sscanf( s, "%d", &_env.stem_fitting_strength );
++    s=getenv( "INFINALITY_FT_CHROMEOS_STYLE_SHARPENING_STRENGTH" );
++    if( s ) _env.chromeos_style_sharpening_strength=int_val( s, 0, 100 );
++    s=getenv( "INFINALITY_FT_BRIGHTNESS" );
++    if( s ) sscanf( s, "%d", &_env.brightness );
++    s=getenv( "INFINALITY_FT_CONTRAST" );
++    if( s ) sscanf( s, "%d", &_env.contrast );
++    s=getenv( "INFINALITY_FT_WINDOWS_STYLE_SHARPENING_STRENGTH" );
++    if( s ) _env.windows_style_sharpening_strength=int_val( s, 0, 100 );
++    s=getenv( "INFINALITY_FT_GAMMA_CORRECTION" );
++    if( s ){
++        float *f=_env.gamma_correction;
++        sscanf ( s, "%f %f", &f[0], &f[1] );
++        if( f[1] < 1.0f ) f[1]=1.0f;
++    }
++    s=getenv( "INFINALITY_FT_FRINGE_FILTER_STRENGTH" );
++    if( s ) sscanf( s, "%d", &_env.fringe_filter_strength );
++    s=getenv( "INFINALITY_FT_GRAYSCALE_FILTER_STRENGTH" );
++    if( s ) sscanf( s, "%d", &_env.grayscale_filter_strength );
++    s=getenv( "INFINALITY_FT_AUTOHINT_HORIZONTAL_STEM_DARKEN_STRENGTH" );
++    if( s ) sscanf( s, "%d", &_env.autohint_horizontal_stem_darken_strength );
++    s=getenv( "INFINALITY_FT_AUTOHINT_VERTICAL_STEM_DARKEN_STRENGTH" );
++    if( s ) sscanf( s, "%d", &_env.autohint_vertical_stem_darken_strength );
++    s=getenv( "INFINALITY_FT_GLOBAL_EMBOLDEN_X_VALUE" );
++    if( s ) sscanf( s, "%d", &_env.global_embolden_x_value );
++    s=getenv( "INFINALITY_FT_GLOBAL_EMBOLDEN_Y_VALUE" );
++    if( s ) sscanf( s, "%d", &_env.global_embolden_y_value );
++    s=getenv( "INFINALITY_FT_BOLD_EMBOLDEN_X_VALUE" );
++    if( s ) sscanf( s, "%d", &_env.bold_embolden_x_value );
++    s=getenv( "INFINALITY_FT_BOLD_EMBOLDEN_Y_VALUE" );
++    if( s ) sscanf( s, "%d", &_env.bold_embolden_y_value );
++    s=getenv( "INFINALITY_FT_FILTER_PARAMS" );
++    if( s ) {
++        int *f=_env.filter_params;
++        if( sscanf( s, "%d %d %d %d %d", f+1, f+2, f+3, f+4, f+5 )==5 )
++            f[0]=on;
++        else
++            f[0]=off;           /* FIXME: put a warning? */
++    }
++    /* do the range verifications as in original code */
++    if ( _env.stem_snapping_sliding_scale > maxp )
++        _env.stem_snapping_sliding_scale = 0;
++    else if ( _env.stem_snapping_sliding_scale < 0 )
++        _env.stem_snapping_sliding_scale = 0;
++    if (_env.stem_snapping_sliding_scale < 11 &&
++        _env.stem_snapping_sliding_scale > 0  )
++        _env.stem_snapping_sliding_scale = 11;
++
++    if ( _env.stem_alignment_strength > 100 )
++        _env.stem_alignment_strength = 100;
++    else if ( _env.stem_alignment_strength < 0 )
++        _env.stem_alignment_strength = 0;
++
++    if ( _env.stem_fitting_strength > 100 )
++        _env.stem_fitting_strength = 100;
++    else if ( _env.stem_fitting_strength < 0 )
++        _env.stem_fitting_strength = 0;
++
++    if ( _env.chromeos_style_sharpening_strength > 100 )
++        _env.chromeos_style_sharpening_strength = 100;
++    else if ( _env.chromeos_style_sharpening_strength < 0 )
++        _env.chromeos_style_sharpening_strength = 0;
++
++    if ( _env.brightness > 100 )
++        _env.brightness = 100;
++    else if ( _env.brightness < -100 )
++        _env.brightness = 0;
++
++    if ( _env.contrast > 100 )
++        _env.contrast = 100;
++    else if ( _env.contrast < -100 )
++        _env.contrast = 0;
++
++    if ( _env.windows_style_sharpening_strength > 100 )
++        _env.windows_style_sharpening_strength = 100;
++    else if ( _env.windows_style_sharpening_strength < 0 )
++        _env.windows_style_sharpening_strength = 0;
++
++    if ( _env.fringe_filter_strength > 100 )
++        _env.fringe_filter_strength = 100;
++    else if ( _env.fringe_filter_strength < 0 )
++        _env.fringe_filter_strength = 0;
++
++    if ( _env.grayscale_filter_strength > 100 )
++        _env.grayscale_filter_strength = 100;
++    else if ( _env.grayscale_filter_strength < 0 )
++        _env.grayscale_filter_strength = 0;
++
++    if ( _env.autohint_horizontal_stem_darken_strength > 100 )
++        _env.autohint_horizontal_stem_darken_strength = 100;
++    else if ( _env.autohint_horizontal_stem_darken_strength < 0 )
++        _env.autohint_horizontal_stem_darken_strength = 0;
++
++    if ( _env.autohint_vertical_stem_darken_strength > 100 )
++        _env.autohint_vertical_stem_darken_strength = 100;
++    else if ( _env.autohint_horizontal_stem_darken_strength < 0 )
++        _env.autohint_vertical_stem_darken_strength = 0;
++
++    if ( _env.global_embolden_x_value > 128 )
++        _env.global_embolden_x_value = 128;
++    else if ( _env.global_embolden_x_value < -128 )
++        _env.global_embolden_x_value = -128;
++
++    if ( _env.global_embolden_y_value > 128 )
++        _env.global_embolden_y_value = 128;
++    else if ( _env.global_embolden_y_value < -128 )
++          _env.global_embolden_y_value = -128;
++
++    if ( _env.bold_embolden_x_value > 128 )
++        _env.bold_embolden_x_value = 128;
++    else if (_env.bold_embolden_x_value < -128 )
++        _env.bold_embolden_x_value = -128;
++
++    if ( _env.bold_embolden_y_value > 128 )
++        _env.bold_embolden_y_value = 128;
++    else if ( _env.bold_embolden_y_value < -128 )
++        _env.bold_embolden_y_value = -128;
++
++    /* point to the combined and checked settings */
++    ftinf=&_env;
++}
+diff --git a/src/base/ftinf.h b/src/base/ftinf.h
+new file mode 100644
+index 0000000..fbe1bd1
+--- /dev/null
++++ b/src/base/ftinf.h
+@@ -0,0 +1,66 @@
++#ifndef _FTINF_H_
++#define _FTINF_H_
++/*
++    Stem snapping rules
++    (base freetype typedefs assumed already included)
++ */
++typedef struct
++{
++    FT_Int       stem_width;
++    FT_Int       stem_spacing;
++    FT_Int       stem_start;
++    FT_Int       stem_scaling;
++    FT_Int       stem_translating_only;
++    FT_Int       stem_translating;
++    float        brightness;
++    float        contrast;
++    FT_Bool      use_100;
++    FT_Bool      synth_stems;
++    FT_Bool      edge_detection;
++    FT_Bool      bearing_correction;
++    FT_Int       m;
++} Stem_Data;
++
++/*
++  Infinality settings
++ */
++typedef struct ftinf_s {
++    const char *name;
++    int autohint_horizontal_stem_darken_strength;
++    int autohint_snap_stem_height;
++    int autohint_increase_glyph_heights;
++    int autohint_vertical_stem_darken_strength;
++    int bold_embolden_x_value;
++    int bold_embolden_y_value;
++    int brightness;
++    int chromeos_style_sharpening_strength;
++    int contrast;
++    int filter_params[6];       /* 1st one used as existence flag */
++    int fringe_filter_strength;
++    float gamma_correction[2];
++    int global_embolden_x_value;
++    int global_embolden_y_value;
++    int grayscale_filter_strength;
++    int stem_alignment_strength;
++    int stem_darkening_autofit;
++    int stem_darkening_cff;
++    int stem_fitting_strength;
++    int stem_snapping_sliding_scale;
++    int use_known_settings_on_selected_fonts;
++    int use_various_tweaks;
++    int windows_style_sharpening_strength;
++} ftinf_t;
++
++extern FT_Pos infinality_cur_width; /* defined in aflatin.c */
++
++extern const ftinf_t *ftinf;    /* active settings */
++
++extern void ftinf_fill_stem_values( Stem_Data *stem_values,
++                                    const char *family, int ppem, int use_known );
++extern void ftinf_get_bc( const char *family, int ppem,
++                          float *brightness, float *contrast );
++
++/* get values from environment (FIXME: maybe update with using user files) */
++extern void ftinf_env();
++
++#endif
+diff --git a/src/base/ftinf_rh.c b/src/base/ftinf_rh.c
+new file mode 100644
+index 0000000..606b567
+--- /dev/null
++++ b/src/base/ftinf_rh.c
+@@ -0,0 +1,626 @@
++/* ANSI-C code produced by gperf version 3.1 */
++/* Command-line: gperf --output-file=ftinf_rh.c ftinf_rh.gperf  */
++/* Computed positions: -k'1,$' */
++
++#if !((' ' == 32) && ('!' == 33) && ('"' == 34) && ('#' == 35) \
++      && ('%' == 37) && ('&' == 38) && ('\'' == 39) && ('(' == 40) \
++      && (')' == 41) && ('*' == 42) && ('+' == 43) && (',' == 44) \
++      && ('-' == 45) && ('.' == 46) && ('/' == 47) && ('0' == 48) \
++      && ('1' == 49) && ('2' == 50) && ('3' == 51) && ('4' == 52) \
++      && ('5' == 53) && ('6' == 54) && ('7' == 55) && ('8' == 56) \
++      && ('9' == 57) && (':' == 58) && (';' == 59) && ('<' == 60) \
++      && ('=' == 61) && ('>' == 62) && ('?' == 63) && ('A' == 65) \
++      && ('B' == 66) && ('C' == 67) && ('D' == 68) && ('E' == 69) \
++      && ('F' == 70) && ('G' == 71) && ('H' == 72) && ('I' == 73) \
++      && ('J' == 74) && ('K' == 75) && ('L' == 76) && ('M' == 77) \
++      && ('N' == 78) && ('O' == 79) && ('P' == 80) && ('Q' == 81) \
++      && ('R' == 82) && ('S' == 83) && ('T' == 84) && ('U' == 85) \
++      && ('V' == 86) && ('W' == 87) && ('X' == 88) && ('Y' == 89) \
++      && ('Z' == 90) && ('[' == 91) && ('\\' == 92) && (']' == 93) \
++      && ('^' == 94) && ('_' == 95) && ('a' == 97) && ('b' == 98) \
++      && ('c' == 99) && ('d' == 100) && ('e' == 101) && ('f' == 102) \
++      && ('g' == 103) && ('h' == 104) && ('i' == 105) && ('j' == 106) \
++      && ('k' == 107) && ('l' == 108) && ('m' == 109) && ('n' == 110) \
++      && ('o' == 111) && ('p' == 112) && ('q' == 113) && ('r' == 114) \
++      && ('s' == 115) && ('t' == 116) && ('u' == 117) && ('v' == 118) \
++      && ('w' == 119) && ('x' == 120) && ('y' == 121) && ('z' == 122) \
++      && ('{' == 123) && ('|' == 124) && ('}' == 125) && ('~' == 126))
++/* The character set is not based on ISO-646.  */
++#error "gperf generated tables don't work with this execution character set. Please report a bug to <bug-gnu-gperf@gnu.org>."
++#endif
++
++#line 9 "ftinf_rh.gperf"
++
++#include <ctype.h>
++static const struct sa_rules_s* _rules_get( const char*str, unsigned len );
++/* maximum key range = 82, duplicates = 0 */
++
++#ifdef __GNUC__
++__inline
++#else
++#ifdef __cplusplus
++inline
++#endif
++#endif
++static unsigned int
++_rules_hash (register const char *str, register unsigned int len)
++{
++  static const unsigned char asso_values[] =
++    {
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85,  0, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85,  5, 45,  5,
++      35, 25, 35, 35, 50, 45, 85, 85,  0, 25,
++      40,  5,  0, 85, 50, 20, 20,  0, 10, 10,
++      85, 10, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85
++    };
++  return len + asso_values[(unsigned char)str[len - 1]] + asso_values[(unsigned char)str[0]];
++}
++
++#ifdef __GNUC__
++__inline
++#if defined __GNUC_STDC_INLINE__ || defined __GNUC_GNU_INLINE__
++__attribute__ ((__gnu_inline__))
++#endif
++#endif
++const struct sa_rules_s *
++_rules_get (register const char *str, register unsigned int len)
++{
++  enum
++    {
++      TOTAL_KEYWORDS = 58,
++      MIN_WORD_LENGTH = 3,
++      MAX_WORD_LENGTH = 24,
++      MIN_HASH_VALUE = 3,
++      MAX_HASH_VALUE = 84
++    };
++
++  static const struct sa_rules_s wordlist[] =
++    {
++#line 15 "ftinf_rh.gperf"
++{   .name="---",
++    .synthesize_stems={on, 13, 13, end}
++},
++#line 253 "ftinf_rh.gperf"
++{   .name="ubuntu",
++    .always_use_100={on, 12, 13, 15, 15, end}
++},
++#line 31 "ftinf_rh.gperf"
++{   .name="arial",
++    .always_use_100={on, 0, maxp, end},
++    .edge_detection={on, 11, 11, 13, 13, end},
++    .spacing={on, 10, 11, 23, 25, 30, end},
++    .start={on, 11, 18, 23, 30, 30, end},
++    .stem_translating={on, 11, 32, end},
++    .stem_translating_only={on, 10, 16, 8, 32, 9, 32, 16, -24, end}
++},
++#line 87 "ftinf_rh.gperf"
++{   .name="corbel",
++    .stem_translating_only={on, 10, 16, end},
++    .stem_widths={on, 10, 21, maxp}
++},
++#line 71 "ftinf_rh.gperf"
++{   .name="canwell",
++    .stem_scaling={on, 13, 0, end}
++},
++#line 216 "ftinf_rh.gperf"
++{   .name="pragmata",
++    .always_use_100={on, 0, maxp, end}
++},
++#line 67 "ftinf_rh.gperf"
++{   .name="cantarell",
++    .stem_translating_only={on, 11, 0, 12, 0, end},
++    .stem_widths={on, 10, 22, maxp,}
++},
++#line 39 "ftinf_rh.gperf"
++{   .name="arimo",
++    .always_use_100={on, 0, maxp, end},
++    .stem_translating={on, 11, 32, end},
++    .stem_translating_only={on, 10, 8, 8, 32, 9, 32, end}
++},
++#line 207 "ftinf_rh.gperf"
++{   .name="optima",
++    .brightness={on, 0, -20, end},
++    .contrast={on, 0, 25, end},
++    .stem_scaling={on, 17, 1, end},
++    .stem_translating_only={on, 10, 0, 11, 0, 12, 0, end}
++},
++#line 63 "ftinf_rh.gperf"
++{   .name="candara",
++    .stem_scaling={on, 14, 1, 17, 1, end},
++    .stem_translating_only={on, 10, 16, end}
++},
++#line 77 "ftinf_rh.gperf"
++{   .name="comfortaa",
++    .stem_widths={on, 10, 19, 22, maxp},
++    .stem_scaling={on, 11, 0, end}
++},
++#line 161 "ftinf_rh.gperf"
++{   .name="liberation mono",
++    .always_use_100={on, 0, maxp, end}
++},
++#line 18 "ftinf_rh.gperf"
++{   .name="andale mono",
++    .always_use_100={on, 0, maxp, end},
++    .stem_scaling={on, 11, 1, end},
++    .stem_widths={on, 10, 21, maxp,}
++},
++#line 256 "ftinf_rh.gperf"
++{   .name="verdana",
++    .always_use_100={on, 0, 14, 16, maxp, end},
++    .stem_scaling={on, 12, 1, 15, 1, end},
++    .stem_translating_only={on, 8, 16, 15, 16, 14, 32, 18, 32, 19, 24, end}
++},
++#line 74 "ftinf_rh.gperf"
++{   .name="century gothic",
++    .stem_widths={on, 10, 22, maxp,}
++},
++#line 91 "ftinf_rh.gperf"
++{   .name="courier new",
++    .always_use_100={on, 12, 12, end},
++    .edge_detection={on, 10, 12, end},
++    .m={on, 13, 1, 14, 1, end}
++},
++#line 23 "ftinf_rh.gperf"
++{   .name="arial narrow",
++    .stem_widths={on, 10, 21, maxp,}
++},
++#line 185 "ftinf_rh.gperf"
++{   .name="luxi sans",
++    .always_use_100={on, 13, 13, end},
++    .stem_widths={on, 10, 17, sw2pv, maxp,}
++},
++#line 225 "ftinf_rh.gperf"
++{   .name="samba",
++    .stem_scaling={on, 11, 0, end}
++},
++#line 233 "ftinf_rh.gperf"
++{   .name="tahoma",
++    .always_use_100={on, 11, 11, 14, maxp, end},
++    .edge_detection={on, 11, 11, end},
++    .spacing={on, 10, 12, 18, 18, 30, end},
++    .start={on, 14, 17, 30, 100, 100, end},
++    .stem_translating={on, 11, 32, end},
++    .stem_translating_only={on, 7, 32, 8, 32, 9, 32, end},
++},
++#line 164 "ftinf_rh.gperf"
++{   .name="liberation sans narrow",
++    .stem_widths={on,10, 22, maxp,}
++},
++#line 81 "ftinf_rh.gperf"
++{   .name="consolas",
++    .always_use_100={on, 0, maxp, end},
++    .stem_translating_only={on, 8, 32, 9, 32, end},
++    .stem_widths={on, 10, 20, maxp,},
++    .stem_scaling={on, 11, 1, end}
++},
++#line 203 "ftinf_rh.gperf"
++{   .name="open sans",
++    .stem_translating_only={on, 10, 16, 9, 16, end},
++    .stem_widths={on, 10, 20, maxp,}
++},
++#line 167 "ftinf_rh.gperf"
++{   .name="liberation sans",
++    .edge_detection={on, 11, 11, end},
++    .stem_translating={on, 11, 32, end},
++    .stem_translating_only={on, 10, 8, 8, 32, 9, 32, end},
++    .stem_widths={on,10, 19, maxp,}
++},
++#line 193 "ftinf_rh.gperf"
++{   .name="monaco",
++    .always_use_100={on, 0, maxp, end}
++},
++#line 101 "ftinf_rh.gperf"
++{   .name="cousine",
++    .always_use_100={on, 0, maxp, end}
++},
++#line 176 "ftinf_rh.gperf"
++{   .name="lucida grande",
++    .stem_scaling={on, 13, 1, end},
++    .stem_translating_only={on, 13, 24, 14, 24, 8, 16, 9, 16, end},
++    .stem_widths={on, 10, 16, sw2pv, maxp},
++},
++#line 173 "ftinf_rh.gperf"
++{   .name="lucida console",
++    .always_use_100={on, 0, maxp, end}
++},
++#line 196 "ftinf_rh.gperf"
++{   .name="myriad pro",
++    .stem_scaling={on, 14, 1, 17, 1, end},
++    .stem_translating_only={on, 10, 16, 11, 0, 9, 16, end}
++},
++#line 26 "ftinf_rh.gperf"
++{   .name="arial unicode ms",
++    .always_use_100={on, 0, maxp, end},
++    .stem_translating={on, 11, 32, end},
++    .stem_translating_only={on, 10, 16, 8, 32, 9, 32, end}
++},
++#line 213 "ftinf_rh.gperf"
++{   .name="palatino linotype",
++    .edge_detection={on, 0, 100, end}
++},
++#line 181 "ftinf_rh.gperf"
++{   .name="lucida sans unicode",
++    .stem_translating_only={on, 13, 24, 14, 24, 8, 16, 9, 16, end},
++    .stem_widths={on,10, 16, sw2pv, maxp,}
++},
++#line 140 "ftinf_rh.gperf"
++{   .name="futura",
++    .stem_widths={on, 10, 14, sw2pv, maxp,}
++},
++#line 147 "ftinf_rh.gperf"
++{   .name="georgia",
++    .stem_translating_only={on, 13, 16, 14, 16, 15, 0, end}
++},
++#line 125 "ftinf_rh.gperf"
++{   .name="freemono",
++    .always_use_100={on, 0, maxp, end}
++},
++#line 200 "ftinf_rh.gperf"
++{   .name="nina",
++    .stem_scaling={on, 11, 0, 12, 0, 13, 0, end}
++},
++#line 121 "ftinf_rh.gperf"
++{   .name="essential pragmatapro",
++    .always_use_100={on, 0, maxp, end},
++    .m={on, 13, 0, 14, 0, end}
++},
++#line 247 "ftinf_rh.gperf"
++{   .name="trebuchet ms",
++    .always_use_100={on, 13, 13, end},
++    .stem_scaling={on, 13, 0, 17, 0, 20, 1, end},
++    .stem_translating_only={on, 10, 16, 11, 0, 8, 32, 9, 32, end},
++    .stem_widths={on, 10, 17, sw2pv, maxp,}
++},
++#line 114 "ftinf_rh.gperf"
++{   .name="droid sans mono",
++    .m={on, 12, 0, end}
++},
++#line 104 "ftinf_rh.gperf"
++{   .name="dejavu sans mono",
++    .always_use_100={on, 0, maxp, end},
++    .stem_translating_only={on, 7, 16, 8, 32, 9, 16, end}
++},
++#line 57 "ftinf_rh.gperf"
++{   .name="calibri",
++    .always_use_100={on, 23, maxp, end},
++    .stem_scaling={on, 15, 1, 17, 1, 18, 1, end},
++    .stem_translating_only={on, 10, 16, 15, 0, end},
++    .stem_widths={on, 1, 10, 19, maxp,}
++},
++#line 156 "ftinf_rh.gperf"
++{   .name="inconsolata",
++    .stem_scaling={on, 12, 1, 15, 1, end},
++    .stem_translating_only={on, 10, 24, 9, 32, end},
++    .stem_widths={on, 10, 23, maxp,},
++},
++#line 96 "ftinf_rh.gperf"
++{   .name="courier",
++    .always_use_100={on, 0, maxp, end},
++    .m={on, 13, 1, 14, 1, end},
++    .stem_translating_only={on, 13, 16, 15, 0, end}
++},
++#line 128 "ftinf_rh.gperf"
++{   .name="freesans",
++    .always_use_100={on, 0, maxp, end},
++    .edge_detection={on, 11, 11, 13, 13, end},
++    .spacing={on, 10, 12, 18, 18, 30, end},
++    .start={on, 10, 18, 18, 25, 30, end},
++    .stem_scaling={on, 16, 0, end},
++    .stem_translating={on, 11, 32, end},
++    .stem_translating_only={on, 10, 16, 9, 8, end}
++},
++#line 150 "ftinf_rh.gperf"
++{   .name="gill sans",
++    .stem_widths={on, 10, 17, sw2pv, maxp,}
++},
++#line 117 "ftinf_rh.gperf"
++{   .name="droid sans",
++    .always_use_100={on, 12, 12, 15, 15, end},
++    .stem_translating_only={on, 8, 16, 9, 16, end}
++},
++#line 108 "ftinf_rh.gperf"
++{   .name="dejavu sans",
++    .always_use_100={on, 10, 14, 16, 17, end},
++    .m={on, 12, 0, end},
++    .stem_scaling={on, 12, 1, end},
++    .stem_translating_only={on, 8, 16, 15, -20, end}
++},
++#line 219 "ftinf_rh.gperf"
++{   .name="raleway",
++    .stem_scaling={on, 15, 0, end}
++},
++#line 153 "ftinf_rh.gperf"
++{   .name="helvetica cy",
++    .stem_widths={on, 10, 23, maxp,}
++},
++#line 228 "ftinf_rh.gperf"
++{   .name="segoe ui",
++    .always_use_100={on, 11, 12, 14, 14, end},
++    .stem_translating_only={on, 10, 0, 7, 32, 8, 16, 9, 24, end},
++    .stem_widths={on, 10, 23, maxp,}
++},
++#line 48 "ftinf_rh.gperf"
++{   .name="bitstream vera sans mono",
++    .always_use_100={on, 0, maxp, end}
++},
++#line 241 "ftinf_rh.gperf"
++{   .name="times new roman",
++    .always_use_100={on, 14, 14, 16, 16, end},
++    .bearing_correction={0, 100, end},
++    .stem_scaling={on, 17, 1, end},
++    .stem_translating_only={on, 17, 8, end}
++},
++#line 222 "ftinf_rh.gperf"
++{   .name="rokkitt",
++    .stem_widths={on, 10, 21, maxp,}
++},
++#line 143 "ftinf_rh.gperf"
++{   .name="garamond",
++    .brightness={on, 0, -20, end},
++    .contrast={on, 0, 25, end}
++},
++#line 137 "ftinf_rh.gperf"
++{   .name="freeserif",
++    .stem_scaling={on, 13, 1, 17, 1, end}
++},
++#line 189 "ftinf_rh.gperf"
++{   .name="microsoft sans serif",
++    .always_use_100={on, 0, maxp, end},
++    .stem_translating_only={on, 10, 16, 8, 32, 9, 32, end}
++},
++#line 44 "ftinf_rh.gperf"
++{   .name="baskerville",
++    .brightness={on, 0, -20, end},
++    .contrast={on, 0, 25, end}
++},
++#line 51 "ftinf_rh.gperf"
++{   .name="bitstream vera sans",
++    .always_use_100={on, 10, 14, 16, 17, end},
++    .m={on, 12, 0, end},
++    .stem_scaling={on ,12, 1, end},
++    .stem_translating_only={on, 8, 16, end}
++}
++    };
++
++  if (len <= MAX_WORD_LENGTH && len >= MIN_WORD_LENGTH)
++    {
++      register int key = _rules_hash (str, len);
++
++      if (key <= MAX_HASH_VALUE && key >= MIN_HASH_VALUE)
++        {
++          register const struct sa_rules_s *resword;
++
++          switch (key - 3)
++            {
++              case 0:
++                resword = &wordlist[0];
++                goto compare;
++              case 3:
++                resword = &wordlist[1];
++                goto compare;
++              case 7:
++                resword = &wordlist[2];
++                goto compare;
++              case 8:
++                resword = &wordlist[3];
++                goto compare;
++              case 9:
++                resword = &wordlist[4];
++                goto compare;
++              case 10:
++                resword = &wordlist[5];
++                goto compare;
++              case 11:
++                resword = &wordlist[6];
++                goto compare;
++              case 12:
++                resword = &wordlist[7];
++                goto compare;
++              case 13:
++                resword = &wordlist[8];
++                goto compare;
++              case 14:
++                resword = &wordlist[9];
++                goto compare;
++              case 16:
++                resword = &wordlist[10];
++                goto compare;
++              case 17:
++                resword = &wordlist[11];
++                goto compare;
++              case 18:
++                resword = &wordlist[12];
++                goto compare;
++              case 19:
++                resword = &wordlist[13];
++                goto compare;
++              case 21:
++                resword = &wordlist[14];
++                goto compare;
++              case 23:
++                resword = &wordlist[15];
++                goto compare;
++              case 24:
++                resword = &wordlist[16];
++                goto compare;
++              case 26:
++                resword = &wordlist[17];
++                goto compare;
++              case 27:
++                resword = &wordlist[18];
++                goto compare;
++              case 28:
++                resword = &wordlist[19];
++                goto compare;
++              case 29:
++                resword = &wordlist[20];
++                goto compare;
++              case 30:
++                resword = &wordlist[21];
++                goto compare;
++              case 31:
++                resword = &wordlist[22];
++                goto compare;
++              case 32:
++                resword = &wordlist[23];
++                goto compare;
++              case 33:
++                resword = &wordlist[24];
++                goto compare;
++              case 34:
++                resword = &wordlist[25];
++                goto compare;
++              case 35:
++                resword = &wordlist[26];
++                goto compare;
++              case 36:
++                resword = &wordlist[27];
++                goto compare;
++              case 37:
++                resword = &wordlist[28];
++                goto compare;
++              case 38:
++                resword = &wordlist[29];
++                goto compare;
++              case 39:
++                resword = &wordlist[30];
++                goto compare;
++              case 41:
++                resword = &wordlist[31];
++                goto compare;
++              case 43:
++                resword = &wordlist[32];
++                goto compare;
++              case 44:
++                resword = &wordlist[33];
++                goto compare;
++              case 45:
++                resword = &wordlist[34];
++                goto compare;
++              case 46:
++                resword = &wordlist[35];
++                goto compare;
++              case 48:
++                resword = &wordlist[36];
++                goto compare;
++              case 49:
++                resword = &wordlist[37];
++                goto compare;
++              case 52:
++                resword = &wordlist[38];
++                goto compare;
++              case 53:
++                resword = &wordlist[39];
++                goto compare;
++              case 54:
++                resword = &wordlist[40];
++                goto compare;
++              case 58:
++                resword = &wordlist[41];
++                goto compare;
++              case 59:
++                resword = &wordlist[42];
++                goto compare;
++              case 60:
++                resword = &wordlist[43];
++                goto compare;
++              case 61:
++                resword = &wordlist[44];
++                goto compare;
++              case 62:
++                resword = &wordlist[45];
++                goto compare;
++              case 63:
++                resword = &wordlist[46];
++                goto compare;
++              case 64:
++                resword = &wordlist[47];
++                goto compare;
++              case 69:
++                resword = &wordlist[48];
++                goto compare;
++              case 70:
++                resword = &wordlist[49];
++                goto compare;
++              case 71:
++                resword = &wordlist[50];
++                goto compare;
++              case 72:
++                resword = &wordlist[51];
++                goto compare;
++              case 74:
++                resword = &wordlist[52];
++                goto compare;
++              case 75:
++                resword = &wordlist[53];
++                goto compare;
++              case 76:
++                resword = &wordlist[54];
++                goto compare;
++              case 77:
++                resword = &wordlist[55];
++                goto compare;
++              case 78:
++                resword = &wordlist[56];
++                goto compare;
++              case 81:
++                resword = &wordlist[57];
++                goto compare;
++            }
++          return 0;
++        compare:
++          {
++            register const char *s = resword->name;
++
++            if (*str == *s && !strcmp (str + 1, s + 1))
++              return resword;
++          }
++        }
++    }
++  return 0;
++}
++#line 261 "ftinf_rh.gperf"
++
++
++static const sa_rules_t*
++ftinf_rules( const char *name ){
++    if( name ){
++        enum {
++            max_wlen=31
++        };
++        char buf[max_wlen+1];
++        int len=strlen( name );
++        if( len <= max_wlen ){
++            int i;
++            for( i=0; i<len; ++i )
++                buf[i]=tolower( name[i] );
++            buf[len]='\0';
++            return _rules_get( buf, len );
++        }
++    }
++    return NULL;
++}
++/*
++   gperf --output-file=ftinf_rh.c ftinf_rh.gperf
++*/
+diff --git a/src/base/ftinf_rh.gperf b/src/base/ftinf_rh.gperf
+new file mode 100644
+index 0000000..9fd8aab
+--- /dev/null
++++ b/src/base/ftinf_rh.gperf
+@@ -0,0 +1,283 @@
++%struct-type
++%define slot-name name
++%enum
++%switch=1
++%readonly-tables
++%omit-struct-type
++%define lookup-function-name  _rules_get
++%define hash-function-name _rules_hash
++%{
++#include <ctype.h>
++static const struct sa_rules_s* _rules_get( const char*str, unsigned len );
++%}
++struct sa_rules_s;
++%%
++{   .name="---",
++    .synthesize_stems={on, 13, 13, end}
++},
++{   .name="andale mono",
++    .always_use_100={on, 0, maxp, end},
++    .stem_scaling={on, 11, 1, end},
++    .stem_widths={on, 10, 21, maxp,}
++},
++{   .name="arial narrow",
++    .stem_widths={on, 10, 21, maxp,}
++},
++{   .name="arial unicode ms",
++    .always_use_100={on, 0, maxp, end},
++    .stem_translating={on, 11, 32, end},
++    .stem_translating_only={on, 10, 16, 8, 32, 9, 32, end}
++},
++{   .name="arial",
++    .always_use_100={on, 0, maxp, end},
++    .edge_detection={on, 11, 11, 13, 13, end},
++    .spacing={on, 10, 11, 23, 25, 30, end},
++    .start={on, 11, 18, 23, 30, 30, end},
++    .stem_translating={on, 11, 32, end},
++    .stem_translating_only={on, 10, 16, 8, 32, 9, 32, 16, -24, end}
++},
++{   .name="arimo",
++    .always_use_100={on, 0, maxp, end},
++    .stem_translating={on, 11, 32, end},
++    .stem_translating_only={on, 10, 8, 8, 32, 9, 32, end}
++},
++{   .name="baskerville",
++    .brightness={on, 0, -20, end},
++    .contrast={on, 0, 25, end}
++},
++{   .name="bitstream vera sans mono",
++    .always_use_100={on, 0, maxp, end}
++},
++{   .name="bitstream vera sans",
++    .always_use_100={on, 10, 14, 16, 17, end},
++    .m={on, 12, 0, end},
++    .stem_scaling={on ,12, 1, end},
++    .stem_translating_only={on, 8, 16, end}
++},
++{   .name="calibri",
++    .always_use_100={on, 23, maxp, end},
++    .stem_scaling={on, 15, 1, 17, 1, 18, 1, end},
++    .stem_translating_only={on, 10, 16, 15, 0, end},
++    .stem_widths={on, 1, 10, 19, maxp,}
++},
++{   .name="candara",
++    .stem_scaling={on, 14, 1, 17, 1, end},
++    .stem_translating_only={on, 10, 16, end}
++},
++{   .name="cantarell",
++    .stem_translating_only={on, 11, 0, 12, 0, end},
++    .stem_widths={on, 10, 22, maxp,}
++},
++{   .name="canwell",
++    .stem_scaling={on, 13, 0, end}
++},
++{   .name="century gothic",
++    .stem_widths={on, 10, 22, maxp,}
++},
++{   .name="comfortaa",
++    .stem_widths={on, 10, 19, 22, maxp},
++    .stem_scaling={on, 11, 0, end}
++},
++{   .name="consolas",
++    .always_use_100={on, 0, maxp, end},
++    .stem_translating_only={on, 8, 32, 9, 32, end},
++    .stem_widths={on, 10, 20, maxp,},
++    .stem_scaling={on, 11, 1, end}
++},
++{   .name="corbel",
++    .stem_translating_only={on, 10, 16, end},
++    .stem_widths={on, 10, 21, maxp}
++},
++{   .name="courier new",
++    .always_use_100={on, 12, 12, end},
++    .edge_detection={on, 10, 12, end},
++    .m={on, 13, 1, 14, 1, end}
++},
++{   .name="courier",
++    .always_use_100={on, 0, maxp, end},
++    .m={on, 13, 1, 14, 1, end},
++    .stem_translating_only={on, 13, 16, 15, 0, end}
++},
++{   .name="cousine",
++    .always_use_100={on, 0, maxp, end}
++},
++{   .name="dejavu sans mono",
++    .always_use_100={on, 0, maxp, end},
++    .stem_translating_only={on, 7, 16, 8, 32, 9, 16, end}
++},
++{   .name="dejavu sans",
++    .always_use_100={on, 10, 14, 16, 17, end},
++    .m={on, 12, 0, end},
++    .stem_scaling={on, 12, 1, end},
++    .stem_translating_only={on, 8, 16, 15, -20, end}
++},
++{   .name="droid sans mono",
++    .m={on, 12, 0, end}
++},
++{   .name="droid sans",
++    .always_use_100={on, 12, 12, 15, 15, end},
++    .stem_translating_only={on, 8, 16, 9, 16, end}
++},
++{   .name="essential pragmatapro",
++    .always_use_100={on, 0, maxp, end},
++    .m={on, 13, 0, 14, 0, end}
++},
++{   .name="freemono",
++    .always_use_100={on, 0, maxp, end}
++},
++{   .name="freesans",
++    .always_use_100={on, 0, maxp, end},
++    .edge_detection={on, 11, 11, 13, 13, end},
++    .spacing={on, 10, 12, 18, 18, 30, end},
++    .start={on, 10, 18, 18, 25, 30, end},
++    .stem_scaling={on, 16, 0, end},
++    .stem_translating={on, 11, 32, end},
++    .stem_translating_only={on, 10, 16, 9, 8, end}
++},
++{   .name="freeserif",
++    .stem_scaling={on, 13, 1, 17, 1, end}
++},
++{   .name="futura",
++    .stem_widths={on, 10, 14, sw2pv, maxp,}
++},
++{   .name="garamond",
++    .brightness={on, 0, -20, end},
++    .contrast={on, 0, 25, end}
++},
++{   .name="georgia",
++    .stem_translating_only={on, 13, 16, 14, 16, 15, 0, end}
++},
++{   .name="gill sans",
++    .stem_widths={on, 10, 17, sw2pv, maxp,}
++},
++{   .name="helvetica cy",
++    .stem_widths={on, 10, 23, maxp,}
++},
++{   .name="inconsolata",
++    .stem_scaling={on, 12, 1, 15, 1, end},
++    .stem_translating_only={on, 10, 24, 9, 32, end},
++    .stem_widths={on, 10, 23, maxp,},
++},
++{   .name="liberation mono",
++    .always_use_100={on, 0, maxp, end}
++},
++{   .name="liberation sans narrow",
++    .stem_widths={on,10, 22, maxp,}
++},
++{   .name="liberation sans",
++    .edge_detection={on, 11, 11, end},
++    .stem_translating={on, 11, 32, end},
++    .stem_translating_only={on, 10, 8, 8, 32, 9, 32, end},
++    .stem_widths={on,10, 19, maxp,}
++},
++{   .name="lucida console",
++    .always_use_100={on, 0, maxp, end}
++},
++{   .name="lucida grande",
++    .stem_scaling={on, 13, 1, end},
++    .stem_translating_only={on, 13, 24, 14, 24, 8, 16, 9, 16, end},
++    .stem_widths={on, 10, 16, sw2pv, maxp},
++},
++{   .name="lucida sans unicode",
++    .stem_translating_only={on, 13, 24, 14, 24, 8, 16, 9, 16, end},
++    .stem_widths={on,10, 16, sw2pv, maxp,}
++},
++{   .name="luxi sans",
++    .always_use_100={on, 13, 13, end},
++    .stem_widths={on, 10, 17, sw2pv, maxp,}
++},
++{   .name="microsoft sans serif",
++    .always_use_100={on, 0, maxp, end},
++    .stem_translating_only={on, 10, 16, 8, 32, 9, 32, end}
++},
++{   .name="monaco",
++    .always_use_100={on, 0, maxp, end}
++},
++{   .name="myriad pro",
++    .stem_scaling={on, 14, 1, 17, 1, end},
++    .stem_translating_only={on, 10, 16, 11, 0, 9, 16, end}
++},
++{   .name="nina",
++    .stem_scaling={on, 11, 0, 12, 0, 13, 0, end}
++},
++{   .name="open sans",
++    .stem_translating_only={on, 10, 16, 9, 16, end},
++    .stem_widths={on, 10, 20, maxp,}
++},
++{   .name="optima",
++    .brightness={on, 0, -20, end},
++    .contrast={on, 0, 25, end},
++    .stem_scaling={on, 17, 1, end},
++    .stem_translating_only={on, 10, 0, 11, 0, 12, 0, end}
++},
++{   .name="palatino linotype",
++    .edge_detection={on, 0, 100, end}
++},
++{   .name="pragmata",
++    .always_use_100={on, 0, maxp, end}
++},
++{   .name="raleway",
++    .stem_scaling={on, 15, 0, end}
++},
++{   .name="rokkitt",
++    .stem_widths={on, 10, 21, maxp,}
++},
++{   .name="samba",
++    .stem_scaling={on, 11, 0, end}
++},
++{   .name="segoe ui",
++    .always_use_100={on, 11, 12, 14, 14, end},
++    .stem_translating_only={on, 10, 0, 7, 32, 8, 16, 9, 24, end},
++    .stem_widths={on, 10, 23, maxp,}
++},
++{   .name="tahoma",
++    .always_use_100={on, 11, 11, 14, maxp, end},
++    .edge_detection={on, 11, 11, end},
++    .spacing={on, 10, 12, 18, 18, 30, end},
++    .start={on, 14, 17, 30, 100, 100, end},
++    .stem_translating={on, 11, 32, end},
++    .stem_translating_only={on, 7, 32, 8, 32, 9, 32, end},
++},
++{   .name="times new roman",
++    .always_use_100={on, 14, 14, 16, 16, end},
++    .bearing_correction={0, 100, end},
++    .stem_scaling={on, 17, 1, end},
++    .stem_translating_only={on, 17, 8, end}
++},
++{   .name="trebuchet ms",
++    .always_use_100={on, 13, 13, end},
++    .stem_scaling={on, 13, 0, 17, 0, 20, 1, end},
++    .stem_translating_only={on, 10, 16, 11, 0, 8, 32, 9, 32, end},
++    .stem_widths={on, 10, 17, sw2pv, maxp,}
++},
++{   .name="ubuntu",
++    .always_use_100={on, 12, 13, 15, 15, end}
++},
++{   .name="verdana",
++    .always_use_100={on, 0, 14, 16, maxp, end},
++    .stem_scaling={on, 12, 1, 15, 1, end},
++    .stem_translating_only={on, 8, 16, 15, 16, 14, 32, 18, 32, 19, 24, end}
++},
++%%
++
++static const sa_rules_t*
++ftinf_rules( const char *name ){
++    if( name ){
++        enum {
++            max_wlen=31
++        };
++        char buf[max_wlen+1];
++        int len=strlen( name );
++        if( len <= max_wlen ){
++            int i;
++            for( i=0; i<len; ++i )
++                buf[i]=tolower( name[i] );
++            buf[len]='\0';
++            return _rules_get( buf, len );
++        }
++    }
++    return NULL;
++}
++/*
++   gperf --output-file=ftinf_rh.c ftinf_rh.gperf
++*/
+diff --git a/src/base/ftinf_sh.c b/src/base/ftinf_sh.c
+new file mode 100644
+index 0000000..87d2ff8
+--- /dev/null
++++ b/src/base/ftinf_sh.c
+@@ -0,0 +1,463 @@
++/* ANSI-C code produced by gperf version 3.1 */
++/* Command-line: gperf --output-file=ftinf_sh.c ftinf_sh.gperf  */
++/* Computed positions: -k'1,$' */
++
++#if !((' ' == 32) && ('!' == 33) && ('"' == 34) && ('#' == 35) \
++      && ('%' == 37) && ('&' == 38) && ('\'' == 39) && ('(' == 40) \
++      && (')' == 41) && ('*' == 42) && ('+' == 43) && (',' == 44) \
++      && ('-' == 45) && ('.' == 46) && ('/' == 47) && ('0' == 48) \
++      && ('1' == 49) && ('2' == 50) && ('3' == 51) && ('4' == 52) \
++      && ('5' == 53) && ('6' == 54) && ('7' == 55) && ('8' == 56) \
++      && ('9' == 57) && (':' == 58) && (';' == 59) && ('<' == 60) \
++      && ('=' == 61) && ('>' == 62) && ('?' == 63) && ('A' == 65) \
++      && ('B' == 66) && ('C' == 67) && ('D' == 68) && ('E' == 69) \
++      && ('F' == 70) && ('G' == 71) && ('H' == 72) && ('I' == 73) \
++      && ('J' == 74) && ('K' == 75) && ('L' == 76) && ('M' == 77) \
++      && ('N' == 78) && ('O' == 79) && ('P' == 80) && ('Q' == 81) \
++      && ('R' == 82) && ('S' == 83) && ('T' == 84) && ('U' == 85) \
++      && ('V' == 86) && ('W' == 87) && ('X' == 88) && ('Y' == 89) \
++      && ('Z' == 90) && ('[' == 91) && ('\\' == 92) && (']' == 93) \
++      && ('^' == 94) && ('_' == 95) && ('a' == 97) && ('b' == 98) \
++      && ('c' == 99) && ('d' == 100) && ('e' == 101) && ('f' == 102) \
++      && ('g' == 103) && ('h' == 104) && ('i' == 105) && ('j' == 106) \
++      && ('k' == 107) && ('l' == 108) && ('m' == 109) && ('n' == 110) \
++      && ('o' == 111) && ('p' == 112) && ('q' == 113) && ('r' == 114) \
++      && ('s' == 115) && ('t' == 116) && ('u' == 117) && ('v' == 118) \
++      && ('w' == 119) && ('x' == 120) && ('y' == 121) && ('z' == 122) \
++      && ('{' == 123) && ('|' == 124) && ('}' == 125) && ('~' == 126))
++/* The character set is not based on ISO-646.  */
++#error "gperf generated tables don't work with this execution character set. Please report a bug to <bug-gnu-gperf@gnu.org>."
++#endif
++
++#line 9 "ftinf_sh.gperf"
++
++#include <ctype.h>
++static const struct ftinf_s* _settings_get( const char*str, unsigned len);
++/* maximum key range = 37, duplicates = 0 */
++
++#ifdef __GNUC__
++__inline
++#else
++#ifdef __cplusplus
++inline
++#endif
++#endif
++static unsigned int
++_settings_hash (register const char *str, register unsigned int len)
++{
++  static const unsigned char asso_values[] =
++    {
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 13,
++       8, 30, 25, 20, 40, 10, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40,  5, 40,  0,
++       0,  0, 40, 40, 10,  0, 40, 40, 15,  5,
++      10,  0, 10, 40, 40,  0,  0,  0,  0,  0,
++       0,  0, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40
++    };
++  return len + asso_values[(unsigned char)str[len - 1]] + asso_values[(unsigned char)str[0]];
++}
++
++#ifdef __GNUC__
++__inline
++#if defined __GNUC_STDC_INLINE__ || defined __GNUC_GNU_INLINE__
++__attribute__ ((__gnu_inline__))
++#endif
++#endif
++const struct ftinf_s *
++_settings_get (register const char *str, register unsigned int len)
++{
++  enum
++    {
++      TOTAL_KEYWORDS = 22,
++      MIN_WORD_LENGTH = 3,
++      MAX_WORD_LENGTH = 14,
++      MIN_HASH_VALUE = 3,
++      MAX_HASH_VALUE = 39
++    };
++
++  static const struct ftinf_s wordlist[] =
++    {
++#line 76 "ftinf_sh.gperf"
++{   .name="osx",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_vertical_stem_darken_strength=25,
++    .bold_embolden_x_value=16,
++    .brightness=10,
++    .contrast=20,
++    .filter_params={on, 3, 32, 38, 32, 3},
++    .gamma_correction={1000, 80},
++    .global_embolden_y_value=8,
++    .grayscale_filter_strength=25,
++},
++#line 37 "ftinf_sh.gperf"
++{   .name="ipad",
++    .filter_params={on, 0, 0, 100, 0, 0},
++    .gamma_correction={1000, 80},
++    .grayscale_filter_strength=100
++},
++#line 114 "ftinf_sh.gperf"
++{   .name="shove",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_increase_glyph_heights=true,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .filter_params={on, 11, 22, 38, 22, 11},
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=100,
++    .stem_fitting_strength=100,
++    .use_known_settings_on_selected_fonts=true,
++    .use_various_tweaks=true
++},
++#line 126 "ftinf_sh.gperf"
++{   .name="ubuntu",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_vertical_stem_darken_strength=25,
++    .brightness=-10,
++    .contrast=15,
++    .filter_params={on, 11, 22, 38, 22, 11},
++    .gamma_correction={1000, 80},
++    .use_various_tweaks=true
++},
++#line 27 "ftinf_sh.gperf"
++{   .name="classic",
++    .autohint_increase_glyph_heights=true,
++    .autohint_snap_stem_height=100,
++    .filter_params={on, 6, 25, 38, 25, 6},
++    .gamma_correction={0, 100},
++    .use_various_tweaks=true
++},
++#line 34 "ftinf_sh.gperf"
++{   .name="disabled",
++    .gamma_correction={0, 100},
++},
++#line 100 "ftinf_sh.gperf"
++{   .name="sharpened",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_increase_glyph_heights=true,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .filter_params={on, 11, 22, 38, 22, 11},
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=25,
++    .stem_fitting_strength=25,
++    .stem_snapping_sliding_scale=40,
++    .use_known_settings_on_selected_fonts=true,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=65
++},
++#line 42 "ftinf_sh.gperf"
++{   .name="infinality",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_increase_glyph_heights=true,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .filter_params={on, 11, 22, 38, 22, 11},
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=25,
++    .stem_fitting_strength=25,
++    .stem_snapping_sliding_scale=40,
++    .use_known_settings_on_selected_fonts=true,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=5
++},
++#line 15 "ftinf_sh.gperf"
++{   .name="custom",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .filter_params={on, 8, 24, 48, 24, 8},
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=75,
++    .stem_fitting_strength=50,
++    .stem_snapping_sliding_scale=30,
++    .use_known_settings_on_selected_fonts=true,
++    .use_various_tweaks=true
++},
++#line 180 "ftinf_sh.gperf"
++{   .name="vanilla",
++    .filter_params={on, 6, 25, 38, 25, 6},
++    .gamma_correction={0, 100},
++},
++#line 184 "ftinf_sh.gperf"
++{   .name="windows7light",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .contrast=20,
++    .filter_params={on, 20, 25, 38, 25, 05},
++    .fringe_filter_strength=100,
++    .gamma_correction={1000, 160},
++    .stem_snapping_sliding_scale=30,
++    .use_known_settings_on_selected_fonts=true,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=100
++},
++#line 226 "ftinf_sh.gperf"
++{   .name="windowsxplight",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .brightness=20,
++    .contrast=30,
++    .filter_params={on, 6, 25, 44, 25, 6},
++    .fringe_filter_strength=100,
++    .gamma_correction={1000, 120},
++    .stem_alignment_strength=15,
++    .stem_fitting_strength=15,
++    .stem_snapping_sliding_scale=30,
++    .use_known_settings_on_selected_fonts=true,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=65
++},
++#line 64 "ftinf_sh.gperf"
++{   .name="nudge",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_increase_glyph_heights=true,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .filter_params={on, 11, 22, 38, 22, 11},
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=25,
++    .stem_fitting_strength=15,
++    .stem_snapping_sliding_scale=30,
++    .use_various_tweaks=true,
++},
++#line 144 "ftinf_sh.gperf"
++{   .name="ultimate2",
++    .filter_params={on, 6, 22, 36, 22, 6},
++    .fringe_filter_strength=25,
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=15,
++    .stem_fitting_strength=15,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=25
++},
++#line 197 "ftinf_sh.gperf"
++{   .name="windows7",
++    .filter_params={on, 20, 25, 42, 25, 06},
++    .fringe_filter_strength=100,
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_vertical_stem_darken_strength=25,
++    .windows_style_sharpening_strength=65,
++    .gamma_correction={1000, 120},
++    .brightness=10,
++    .contrast=20,
++    .use_various_tweaks=true,
++    .autohint_snap_stem_height=100,
++    .use_known_settings_on_selected_fonts=true,
++},
++#line 210 "ftinf_sh.gperf"
++{   .name="windowsxp",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .brightness=10,
++    .contrast=20,
++    .filter_params={on, 6, 25, 44, 25, 6},
++    .fringe_filter_strength=100,
++    .gamma_correction={1000, 120},
++    .stem_alignment_strength=15,
++    .stem_fitting_strength=15,
++    .stem_snapping_sliding_scale=30,
++    .use_known_settings_on_selected_fonts=true,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=65
++},
++#line 56 "ftinf_sh.gperf"
++{   .name="linux",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .filter_params={on, 6, 25, 44, 25, 6},
++    .gamma_correction={0, 100},
++    .use_various_tweaks=true
++},
++#line 135 "ftinf_sh.gperf"
++{   .name="ultimate1",
++    .filter_params={on, 4, 22, 38, 22, 4},
++    .fringe_filter_strength=25,
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=15,
++    .stem_fitting_strength=15,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=25
++},
++#line 87 "ftinf_sh.gperf"
++{   .name="push",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_increase_glyph_heights=true,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .filter_params={on, 11, 22, 38, 22, 11},
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=75,
++    .stem_fitting_strength=50,
++    .stem_snapping_sliding_scale=30,
++    .use_known_settings_on_selected_fonts=true,
++    .use_various_tweaks=true
++},
++#line 171 "ftinf_sh.gperf"
++{   .name="ultimate5",
++    .filter_params={on, 12, 28, 42, 28, 12},
++    .fringe_filter_strength=25,
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=15,
++    .stem_fitting_strength=15,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=25
++},
++#line 162 "ftinf_sh.gperf"
++{   .name="ultimate4",
++    .filter_params={on, 10, 25, 37, 25, 10},
++    .fringe_filter_strength=25,
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=15,
++    .stem_fitting_strength=15,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=25
++},
++#line 153 "ftinf_sh.gperf"
++{   .name="ultimate3",
++    .filter_params={on, 8, 24, 36, 24, 8},
++    .fringe_filter_strength=25,
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=15,
++    .stem_fitting_strength=15,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=25
++}
++    };
++
++  if (len <= MAX_WORD_LENGTH && len >= MIN_WORD_LENGTH)
++    {
++      register int key = _settings_hash (str, len);
++
++      if (key <= MAX_HASH_VALUE && key >= MIN_HASH_VALUE)
++        {
++          register const struct ftinf_s *resword;
++
++          switch (key - 3)
++            {
++              case 0:
++                resword = &wordlist[0];
++                goto compare;
++              case 1:
++                resword = &wordlist[1];
++                goto compare;
++              case 2:
++                resword = &wordlist[2];
++                goto compare;
++              case 3:
++                resword = &wordlist[3];
++                goto compare;
++              case 4:
++                resword = &wordlist[4];
++                goto compare;
++              case 5:
++                resword = &wordlist[5];
++                goto compare;
++              case 6:
++                resword = &wordlist[6];
++                goto compare;
++              case 7:
++                resword = &wordlist[7];
++                goto compare;
++              case 8:
++                resword = &wordlist[8];
++                goto compare;
++              case 9:
++                resword = &wordlist[9];
++                goto compare;
++              case 10:
++                resword = &wordlist[10];
++                goto compare;
++              case 11:
++                resword = &wordlist[11];
++                goto compare;
++              case 12:
++                resword = &wordlist[12];
++                goto compare;
++              case 14:
++                resword = &wordlist[13];
++                goto compare;
++              case 15:
++                resword = &wordlist[14];
++                goto compare;
++              case 16:
++                resword = &wordlist[15];
++                goto compare;
++              case 17:
++                resword = &wordlist[16];
++                goto compare;
++              case 19:
++                resword = &wordlist[17];
++                goto compare;
++              case 21:
++                resword = &wordlist[18];
++                goto compare;
++              case 26:
++                resword = &wordlist[19];
++                goto compare;
++              case 31:
++                resword = &wordlist[20];
++                goto compare;
++              case 36:
++                resword = &wordlist[21];
++                goto compare;
++            }
++          return 0;
++        compare:
++          {
++            register const char *s = resword->name;
++
++            if (*str == *s && !strcmp (str + 1, s + 1))
++              return resword;
++          }
++        }
++    }
++  return 0;
++}
++#line 242 "ftinf_sh.gperf"
++
++
++static const ftinf_t*
++ftinf_settings( const char *name ){
++    if( name ){
++        enum {
++            max_wlen=31
++        };
++        char buf[max_wlen+1];
++        int len=strlen( name );
++        if( len <= max_wlen ){
++            int i;
++            for( i=0; i<len; ++i )
++                buf[i]=tolower( name[i] );
++            buf[len]='\0';
++            return _settings_get( buf, len );
++        }
++    }
++    return NULL;
++}
++/*
++   gperf --output-file=ftinf_sh.c ftinf_sh.gperf
++*/
+diff --git a/src/base/ftinf_sh.gperf b/src/base/ftinf_sh.gperf
+new file mode 100644
+index 0000000..5f6e0ae
+--- /dev/null
++++ b/src/base/ftinf_sh.gperf
+@@ -0,0 +1,264 @@
++%struct-type
++%define slot-name name
++%enum
++%switch=1
++%readonly-tables
++%omit-struct-type
++%define lookup-function-name   _settings_get
++%define hash-function-name _settings_hash
++%{
++#include <ctype.h>
++static const struct ftinf_s* _settings_get( const char*str, unsigned len);
++%}
++struct ftinf_s;
++%%
++{   .name="custom",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .filter_params={on, 8, 24, 48, 24, 8},
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=75,
++    .stem_fitting_strength=50,
++    .stem_snapping_sliding_scale=30,
++    .use_known_settings_on_selected_fonts=true,
++    .use_various_tweaks=true
++},
++{   .name="classic",
++    .autohint_increase_glyph_heights=true,
++    .autohint_snap_stem_height=100,
++    .filter_params={on, 6, 25, 38, 25, 6},
++    .gamma_correction={0, 100},
++    .use_various_tweaks=true
++},
++{   .name="disabled",
++    .gamma_correction={0, 100},
++},
++{   .name="ipad",
++    .filter_params={on, 0, 0, 100, 0, 0},
++    .gamma_correction={1000, 80},
++    .grayscale_filter_strength=100
++},
++{   .name="infinality",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_increase_glyph_heights=true,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .filter_params={on, 11, 22, 38, 22, 11},
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=25,
++    .stem_fitting_strength=25,
++    .stem_snapping_sliding_scale=40,
++    .use_known_settings_on_selected_fonts=true,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=5
++},
++{   .name="linux",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .filter_params={on, 6, 25, 44, 25, 6},
++    .gamma_correction={0, 100},
++    .use_various_tweaks=true
++},
++{   .name="nudge",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_increase_glyph_heights=true,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .filter_params={on, 11, 22, 38, 22, 11},
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=25,
++    .stem_fitting_strength=15,
++    .stem_snapping_sliding_scale=30,
++    .use_various_tweaks=true,
++},
++{   .name="osx",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_vertical_stem_darken_strength=25,
++    .bold_embolden_x_value=16,
++    .brightness=10,
++    .contrast=20,
++    .filter_params={on, 3, 32, 38, 32, 3},
++    .gamma_correction={1000, 80},
++    .global_embolden_y_value=8,
++    .grayscale_filter_strength=25,
++},
++{   .name="push",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_increase_glyph_heights=true,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .filter_params={on, 11, 22, 38, 22, 11},
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=75,
++    .stem_fitting_strength=50,
++    .stem_snapping_sliding_scale=30,
++    .use_known_settings_on_selected_fonts=true,
++    .use_various_tweaks=true
++},
++{   .name="sharpened",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_increase_glyph_heights=true,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .filter_params={on, 11, 22, 38, 22, 11},
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=25,
++    .stem_fitting_strength=25,
++    .stem_snapping_sliding_scale=40,
++    .use_known_settings_on_selected_fonts=true,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=65
++},
++{   .name="shove",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_increase_glyph_heights=true,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .filter_params={on, 11, 22, 38, 22, 11},
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=100,
++    .stem_fitting_strength=100,
++    .use_known_settings_on_selected_fonts=true,
++    .use_various_tweaks=true
++},
++{   .name="ubuntu",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_vertical_stem_darken_strength=25,
++    .brightness=-10,
++    .contrast=15,
++    .filter_params={on, 11, 22, 38, 22, 11},
++    .gamma_correction={1000, 80},
++    .use_various_tweaks=true
++},
++{   .name="ultimate1",
++    .filter_params={on, 4, 22, 38, 22, 4},
++    .fringe_filter_strength=25,
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=15,
++    .stem_fitting_strength=15,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=25
++},
++{   .name="ultimate2",
++    .filter_params={on, 6, 22, 36, 22, 6},
++    .fringe_filter_strength=25,
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=15,
++    .stem_fitting_strength=15,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=25
++},
++{   .name="ultimate3",
++    .filter_params={on, 8, 24, 36, 24, 8},
++    .fringe_filter_strength=25,
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=15,
++    .stem_fitting_strength=15,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=25
++},
++{   .name="ultimate4",
++    .filter_params={on, 10, 25, 37, 25, 10},
++    .fringe_filter_strength=25,
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=15,
++    .stem_fitting_strength=15,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=25
++},
++{   .name="ultimate5",
++    .filter_params={on, 12, 28, 42, 28, 12},
++    .fringe_filter_strength=25,
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=15,
++    .stem_fitting_strength=15,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=25
++},
++{   .name="vanilla",
++    .filter_params={on, 6, 25, 38, 25, 6},
++    .gamma_correction={0, 100},
++},
++{   .name="windows7light",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .contrast=20,
++    .filter_params={on, 20, 25, 38, 25, 05},
++    .fringe_filter_strength=100,
++    .gamma_correction={1000, 160},
++    .stem_snapping_sliding_scale=30,
++    .use_known_settings_on_selected_fonts=true,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=100
++},
++{   .name="windows7",
++    .filter_params={on, 20, 25, 42, 25, 06},
++    .fringe_filter_strength=100,
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_vertical_stem_darken_strength=25,
++    .windows_style_sharpening_strength=65,
++    .gamma_correction={1000, 120},
++    .brightness=10,
++    .contrast=20,
++    .use_various_tweaks=true,
++    .autohint_snap_stem_height=100,
++    .use_known_settings_on_selected_fonts=true,
++},
++{   .name="windowsxp",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .brightness=10,
++    .contrast=20,
++    .filter_params={on, 6, 25, 44, 25, 6},
++    .fringe_filter_strength=100,
++    .gamma_correction={1000, 120},
++    .stem_alignment_strength=15,
++    .stem_fitting_strength=15,
++    .stem_snapping_sliding_scale=30,
++    .use_known_settings_on_selected_fonts=true,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=65
++},
++{   .name="windowsxplight",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .brightness=20,
++    .contrast=30,
++    .filter_params={on, 6, 25, 44, 25, 6},
++    .fringe_filter_strength=100,
++    .gamma_correction={1000, 120},
++    .stem_alignment_strength=15,
++    .stem_fitting_strength=15,
++    .stem_snapping_sliding_scale=30,
++    .use_known_settings_on_selected_fonts=true,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=65
++},
++%%
++
++static const ftinf_t*
++ftinf_settings( const char *name ){
++    if( name ){
++        enum {
++            max_wlen=31
++        };
++        char buf[max_wlen+1];
++        int len=strlen( name );
++        if( len <= max_wlen ){
++            int i;
++            for( i=0; i<len; ++i )
++                buf[i]=tolower( name[i] );
++            buf[len]='\0';
++            return _settings_get( buf, len );
++        }
++    }
++    return NULL;
++}
++/*
++   gperf --output-file=ftinf_sh.c ftinf_sh.gperf
++*/
 diff --git a/src/base/ftinit.c b/src/base/ftinit.c
 index b3b08fa..c125db9 100644
 --- a/src/base/ftinit.c
@@ -501,7 +2614,7 @@ index b3b08fa..c125db9 100644
      return error;
    }
 diff --git a/src/base/ftlcdfil.c b/src/base/ftlcdfil.c
-index 611b39f..0e7048c 100644
+index 611b39f..f59793a 100644
 --- a/src/base/ftlcdfil.c
 +++ b/src/base/ftlcdfil.c
 @@ -22,7 +22,10 @@
@@ -516,7 +2629,7 @@ index 611b39f..0e7048c 100644
  
  #ifdef FT_CONFIG_OPTION_SUBPIXEL_RENDERING
  
-@@ -306,11 +309,36 @@
+@@ -306,11 +309,37 @@
    FT_Library_SetLcdFilter( FT_Library    library,
                             FT_LcdFilter  filter )
    {
@@ -524,10 +2637,10 @@ index 611b39f..0e7048c 100644
 -                   { 0x08, 0x4d, 0x56, 0x4d, 0x08 };
      static const FT_LcdFiveTapFilter  light_weights =
                     { 0x00, 0x55, 0x56, 0x55, 0x00 };
--
+ 
 +#ifndef FT_CONFIG_OPTION_INFINALITY_PATCHSET
 +    static const FT_LcdFiveTapFilter  default_weights =
-+                            { 0x08, 0x4d, 0x56, 0x4d, 0x08 };
++                   { 0x08, 0x4d, 0x56, 0x4d, 0x08 };
 +#else
 +    FT_LcdFiveTapFilter default_weights;
 +    if( ftinf && ftinf->filter_params[0] )
@@ -799,7 +2912,7 @@ index 6161393..8c00aa9 100644
      driver->darken_params[0] = CFF_CONFIG_OPTION_DARKENING_PARAMETER_X1;
      driver->darken_params[1] = CFF_CONFIG_OPTION_DARKENING_PARAMETER_Y1;
 diff --git a/src/smooth/ftsmooth.c b/src/smooth/ftsmooth.c
-index 435854e..5d79844 100644
+index 435854e..d14cd1a 100644
 --- a/src/smooth/ftsmooth.c
 +++ b/src/smooth/ftsmooth.c
 @@ -26,6 +26,18 @@
@@ -1039,7 +3152,7 @@ index 435854e..5d79844 100644
 +    FT_Bitmap new_bitmap;
 +
 +
-+    FT_Bitmap_New( &new_bitmap );
++    FT_Bitmap_Init( &new_bitmap );
 +    FT_Bitmap_Copy( library, bitmap, &new_bitmap );
 +    new_line = (&new_bitmap)->buffer;
 +
@@ -1217,7 +3330,7 @@ index 435854e..5d79844 100644
 +    int       factor1, factor2;
 +    int       bias = 0;
 +
-+    FT_Bitmap_New( &new_bitmap );
++    FT_Bitmap_Init( &new_bitmap );
 +
 +    FT_Bitmap_Copy( library, bitmap, &new_bitmap );
 +    new_line = (&new_bitmap)->buffer;
@@ -1291,7 +3404,7 @@ index 435854e..5d79844 100644
 +    FT_Bitmap   new_bitmap;
 +
 +
-+    FT_Bitmap_New( &new_bitmap );
++    FT_Bitmap_Init( &new_bitmap );
 +    FT_Bitmap_Copy( library, bitmap, &new_bitmap );
 +    new_line = (&new_bitmap)->buffer;
 +
@@ -1333,7 +3446,7 @@ index 435854e..5d79844 100644
 +    FT_Bitmap new_bitmap;
 +
 +
-+    FT_Bitmap_New( &new_bitmap );
++    FT_Bitmap_Init( &new_bitmap );
 +    FT_Bitmap_Copy( library, bitmap, &new_bitmap );
 +    new_line = (&new_bitmap)->buffer;
 +
@@ -1382,7 +3495,7 @@ index 435854e..5d79844 100644
 +    FT_UInt   xx;
 +
 +
-+    FT_Bitmap_New(&new_bitmap);
++    FT_Bitmap_Init(&new_bitmap);
 +    FT_Bitmap_Copy(library, bitmap, &new_bitmap);
 +    new_line = (&new_bitmap)->buffer;
 +
@@ -1453,7 +3566,7 @@ index 435854e..5d79844 100644
 +    FT_Bitmap   new_bitmap;
 +
 +
-+    FT_Bitmap_New(&new_bitmap);
++    FT_Bitmap_Init(&new_bitmap);
 +
 +    line = bitmap->buffer;
 +    FT_Bitmap_Copy( library, bitmap, &new_bitmap );
@@ -3195,7 +5308,7 @@ index 435854e..5d79844 100644
 +
 +    FT_Int       brightness_value = 0.0;
 +    FT_Int       contrast_value = 0.0;
-+ 
++
 +    FT_Int       snapping_sliding_scale_value = 0;
 +
 +    FT_Int       global_embolden_x_value = 0;
@@ -3483,7 +5596,7 @@ index 435854e..5d79844 100644
          x_left  -= lcd_extra >> 1;
          width   += 3 * lcd_extra;
          pitch    = FT_PAD_CEIL( width, 4 );
-@@ -243,24 +2712,17 @@
+@@ -243,23 +2712,16 @@
  
        if ( vmul )
        {
@@ -3506,12 +5619,11 @@ index 435854e..5d79844 100644
 -      goto Exit;
 +#ifdef FT_CONFIG_OPTION_INFINALITY_PATCHSET
      }
- 
 +#endif
 +
+ 
      /* Required check is (pitch * height < FT_ULONG_MAX),        */
      /* but we care realistic cases only.  Always pitch <= width. */
-     if ( width > 0x7FFF || height > 0x7FFF )
 @@ -271,6 +2733,22 @@
        goto Exit;
      }
@@ -3567,7 +5679,7 @@ index 435854e..5d79844 100644
      /* set up parameters */
      params.target = bitmap;
      params.source = outline;
-@@ -348,9 +2808,153 @@
+@@ -348,8 +2808,152 @@
      if ( error )
        goto Exit;
  
@@ -3692,7 +5804,7 @@ index 435854e..5d79844 100644
 +
 +
 +        if ( lcd_filter_func )
-+          lcd_filter_func( bitmap, mode, slot->library );
++          lcd_filter_func( bitmap, mode, lcd_weights );
 +
 +        if ( grayscale_filter_strength > 0 )
 +          _ft_lcd_grayscale_filter( bitmap,
@@ -3712,15 +5824,14 @@ index 435854e..5d79844 100644
 +    }
 +    else if ( mode == FT_RENDER_MODE_LCD     &&
 +              lcd_filter_func )
-+          lcd_filter_func( bitmap, mode, slot->library );
++          lcd_filter_func( bitmap, mode, lcd_weights );
 +#else
      if ( lcd_filter_func )
        lcd_filter_func( bitmap, mode, lcd_weights );
- 
 +#endif /* FT_CONFIG_OPTION_INFINALITY_PATCHSET */
+ 
  #else /* !FT_CONFIG_OPTION_SUBPIXEL_RENDERING */
  
-     /* render outline into bitmap */
 @@ -408,6 +3012,20 @@
  
  #endif /* !FT_CONFIG_OPTION_SUBPIXEL_RENDERING */

--- a/01_freetype2-iu/PKGBUILD
+++ b/01_freetype2-iu/PKGBUILD
@@ -2,9 +2,9 @@
 # Maintainer: Jan de Groot <jgc@archlinux.org>
 
 pkgname=freetype2-infinality-ultimate
-pkgver=2.7.1
-pkgrel=2
-_patchrel=2017.01.11
+pkgver=2.8
+pkgrel=1
+_patchrel=2017.05.24
 pkgdesc="TrueType font rendering library with Infinality patches and custom settings by bohoomil"
 arch=(i686 x86_64)
 license=('GPL')
@@ -22,9 +22,9 @@ source=(http://downloads.sourceforge.net/sourceforge/freetype/freetype-${pkgver}
 	0002-infinality-${pkgver}-${_patchrel}.patch
 	freetype2.sh)
 
-sha1sums=('4d08a9a6567c6332d58e9a5f9a7e9e3fbce66789'
+sha1sums=('42c6b1f733fe13a3eba135f5025b22cb68450f91'
           'b31882ef5e8447e761acee1c4a44c0630cd4d465'
-          '7a23342d5d56274ff8a05c67f64b96e85929f629'
+          '4b442f097eeae28516b43c659a3d7a679129052c'
           'bc6df1661c4c33e20f5ce30c2da8ad3c2083665f')
 
 prepare() {

--- a/01_lib32-freetype2-iu/0002-infinality-2.8-2017.05.24.patch
+++ b/01_lib32-freetype2-iu/0002-infinality-2.8-2017.05.24.patch
@@ -1,7 +1,7 @@
-From b0f880b8216e56ad48d4c3b59a0d565fcace8e12 Mon Sep 17 00:00:00 2001
+From 48c2930e9b83c47457ca03f5f8e6f1b61540a8e6 Mon Sep 17 00:00:00 2001
 From: "Devin J. Pohly" <djpohly@gmail.com>
-Date: Mon, 22 May 2017 12:39:32 -0500
-Subject: [PATCH] infinality 2.8 2017.05.22
+Date: Wed, 24 May 2017 15:08:52 -0500
+Subject: [PATCH] infinality 2.8 2017.05.24
 
 ---
  builds/freetype.mk                 |    1 +
@@ -13,8 +13,14 @@ Subject: [PATCH] infinality 2.8 2017.05.22
  src/autofit/afmodule.c             |    7 +
  src/base/Jamfile                   |    1 +
  src/base/ftbase.c                  |    3 +
+ src/base/ftinf.c                   |  363 +++++
+ src/base/ftinf.h                   |   66 +
+ src/base/ftinf_rh.c                |  626 ++++++++
+ src/base/ftinf_rh.gperf            |  283 ++++
+ src/base/ftinf_sh.c                |  463 ++++++
+ src/base/ftinf_sh.gperf            |  264 ++++
  src/base/ftinit.c                  |   14 +-
- src/base/ftlcdfil.c                |   36 +-
+ src/base/ftlcdfil.c                |   35 +-
  src/base/ftobjs.c                  |   67 +-
  src/base/ftoutln.c                 |   10 +-
  src/base/ftsynth.c                 |   22 +-
@@ -22,7 +28,13 @@ Subject: [PATCH] infinality 2.8 2017.05.22
  src/cff/cffobjs.c                  |    6 +
  src/smooth/ftsmooth.c              | 2808 ++++++++++++++++++++++++++++++++++--
  src/truetype/ttinterp.c            |    1 +
- 18 files changed, 3057 insertions(+), 122 deletions(-)
+ 24 files changed, 5122 insertions(+), 121 deletions(-)
+ create mode 100644 src/base/ftinf.c
+ create mode 100644 src/base/ftinf.h
+ create mode 100644 src/base/ftinf_rh.c
+ create mode 100644 src/base/ftinf_rh.gperf
+ create mode 100644 src/base/ftinf_sh.c
+ create mode 100644 src/base/ftinf_sh.gperf
 
 diff --git a/builds/freetype.mk b/builds/freetype.mk
 index f8cfd41..7e7ac5b 100644
@@ -467,6 +479,2107 @@ index 55f7359..4d50dca 100644
  
  
  /* END */
+diff --git a/src/base/ftinf.c b/src/base/ftinf.c
+new file mode 100644
+index 0000000..5d6b7f6
+--- /dev/null
++++ b/src/base/ftinf.c
+@@ -0,0 +1,363 @@
++#include <stdlib.h>
++#include "ftinf.h"
++#define true  1
++#define false 0
++
++#define on  1
++#define off 0
++#define end (-128)
++
++#define sw2pv 18  /* STEM_WIDTH_2_PPEM */
++#define maxp 100  /* MAX_PPEM */
++
++typedef signed char pv;         /* ppm and values type */
++/* the arrays start with existence flag + values */
++typedef struct sa_rules_s {
++    const char *name;
++    pv always_use_100[1+4+1];
++    pv brightness[1+2+1];
++    pv contrast[1+2+1];
++    pv edge_detection[1+4+1];
++    pv m[1+4+1];
++    pv bearing_correction[1+2+1];
++    pv spacing[1+5+1];
++    pv start[1+5+1];
++    pv stem_scaling[1+6+1];
++    pv stem_translating[1+2+1];
++    pv stem_translating_only[1+10+1];
++    pv stem_widths[1+4];        /* these end with maxp */
++    pv synthesize_stems[1+2+1];
++} sa_rules_t;
++
++#pragma GCC diagnostic ignored "-Wpedantic" /* C99 struct initializer tags are needed */
++#pragma GCC diagnostic ignored "-Wunused-function"
++
++const ftinf_t *ftinf;
++/* final settings, updated from environment */
++ftinf_t _env;
++
++/* rules and hashing function */
++#include "ftinf_rh.c"
++
++/* rules selection */
++void ftinf_fill_stem_values( Stem_Data *stem_values,
++                             const char *family, int ppem, int use_known ){
++    /* set the defaults */
++    stem_values->bearing_correction = TRUE;
++    stem_values->brightness = 0.0;
++    stem_values->contrast = 0.0;
++    stem_values->edge_detection = FALSE;
++    stem_values->m = -1;
++    stem_values->stem_scaling = -1;
++    stem_values->stem_spacing = -1;
++    stem_values->stem_start = -1;
++    stem_values->stem_translating = 0;
++    stem_values->stem_translating_only = -1024;
++    stem_values->stem_width = -1;
++    stem_values->synth_stems = FALSE;
++    stem_values->use_100 = FALSE;
++    /* pick from known rules if requested and they exist for current family */
++    if( !use_known )
++        return;
++    else {
++        const sa_rules_t *r=ftinf_rules( family );
++        int i;
++        if( r==NULL ) return;
++        if( r->stem_widths[0]==on )
++            for( i=1; r->stem_widths[i]!=maxp; ++i )
++                if( ppem < r->stem_widths[i] ){
++                    stem_values->stem_width = i-1;
++                    break;
++                }
++
++        if( r->stem_scaling[0]==on )
++            for( i=1; r->stem_scaling[i]!=end; i+=2 )
++                if( ppem==r->stem_scaling[i] ){
++                    stem_values->stem_scaling = r->stem_scaling[i+1];
++                    break;
++                }
++
++        if( r->m[0]==on )
++            for( i=1; r->m[i]!=end; i+=2 )
++                if( ppem==r->m[i] ){
++                    stem_values->m = r->m[i+1];
++                    break;
++                }
++
++        if( r->stem_translating_only[0]==on )
++            for( i=1; r->stem_translating_only[i]!=end; i+=2 )
++                if( ppem==r->stem_translating_only[i] || r->stem_translating_only[i]==0 ){
++                    stem_values->stem_translating_only = r->stem_translating_only[i+1];
++                    break;
++                }
++
++        if( r->stem_translating[0]==on )
++            for( i=1; r->stem_translating[i]!=end; i+=2 )
++                if( ppem==r->stem_translating[i] || r->stem_translating[i]==0 ){
++                    stem_values->stem_translating = r->stem_translating[i+1];
++                    break;
++                }
++
++        if( r->always_use_100[0]==on )
++            for( i=1; r->always_use_100[i]!=end; i+=2 )
++                if( ppem>=r->always_use_100[i] && ppem<=r->always_use_100[i+1] ){
++                    stem_values->use_100 = TRUE;
++                    break;
++                }
++
++        if( r->synthesize_stems[0]==on )
++            for( i=1; r->synthesize_stems[i]!=end; i+=2 )
++                if( ppem>=r->synthesize_stems[i] && ppem<=r->synthesize_stems[i+1] ){
++                    stem_values->synth_stems = TRUE;
++                    break;
++                }
++
++        if( r->edge_detection[0]==on )
++            for( i=1; r->edge_detection[i]!=end; i+=2 )
++                if( ppem>=r->edge_detection[i] && ppem<=r->edge_detection[i+1] ){
++                    stem_values->edge_detection = TRUE;
++                    break;
++                }
++
++        if( r->bearing_correction[0]==on )
++            for( i=1; r->bearing_correction[i]!=end; i+=2 )
++                if( ppem>=r->bearing_correction[i] && ppem<=r->bearing_correction[i+1] ){
++                    stem_values->bearing_correction = FALSE;
++                    break;
++                }
++
++#if(0)
++        if( r->brightness[0]==on )
++            for( i=1; r->brightness[i]!=end; i+=2 )
++                if( ppem==r->brightness[i]||r->brightness[i]==0 ){
++                    stem_values->brightness=r->brightness[i+1]*(1.0f/300.0f);
++                    break;
++                }
++
++        if( r->contrast[0]==on )
++            for( i=1; r->contrast[i]!=end; i+=2 )
++                if( ppem==r->contrast[i]||r->contrast[i]==0 ){
++                    stem_values->contrast=r->contrast[i+1]*(1.0f/300.0f);
++                    break;
++                }
++        if( r->spacing[0]==on ){
++            /* not used by original code */
++        }
++        if( r->start[0]==on ){
++            /* not used by original code */
++        }
++#endif
++    }
++    return;
++}
++
++void ftinf_get_bc( const char *family, int ppem, float *brightness, float *contrast ){
++    const sa_rules_t *r=ftinf_rules( family );
++    *brightness=0;
++    *contrast=0;
++    if( r ){
++        int i;
++        if( r->brightness[0]==on )
++            for( i=1; r->brightness[i]!=end; i+=2 )
++                if( ppem==r->brightness[i]||r->brightness[i]==0 ){
++                    *brightness=r->brightness[i+1]*(1.0f/300.0f);
++                    break;
++                }
++
++        if( r->contrast[0]==on )
++            for( i=1; r->contrast[i]!=end; i+=2 )
++                if( ppem==r->contrast[i]||r->contrast[i]==0 ){
++                    *contrast=r->contrast[i+1]*(1.0f/300.0f);
++                    break;
++                }
++    }
++    return;
++}
++
++static int
++bool_val( const char *s ){
++    if ( s != NULL )
++        return strcasecmp(s, "true") == 0
++            || strcasecmp(s, "1") == 0
++            || strcasecmp(s, "on") == 0
++            || strcasecmp(s, "yes") ==0;
++    else
++        return 0;
++}
++
++static int
++int_val( const char *s, int min, int max ){
++    int val;
++    sscanf ( s, "%d", &val );
++    if ( val > max )
++        val = max;
++    else if ( val < min )
++        val = min;
++    return val;
++}
++
++/* settings and hashing function */
++#include "ftinf_sh.c"
++
++/*
++  Get active Infinality settings
++ */
++void ftinf_env(){
++    const char *s;
++    ftinf=ftinf_settings( getenv( "INFINALITY_FT" ) );
++
++    if( ftinf==NULL ){
++        ftinf=ftinf_settings( "ultimate3" );
++        /* this should always succeed */
++#if(0)
++        if( ftinf==NULL ){
++            /* put an error here */
++            exit(-1);
++        }
++#endif
++    }
++    _env=ftinf[0];      /* copy as defaults */
++
++    /* check if custom environment values are set and update with them */
++    s=getenv( "INFINALITY_FT_AUTOHINT_INCREASE_GLYPH_HEIGHTS" );
++    if( s ) _env.autohint_increase_glyph_heights=bool_val( s );
++    s=getenv( "INFINALITY_FT_AUTOHINT_SNAP_STEM_HEIGHT" );
++    if( s ) _env.autohint_snap_stem_height=int_val( s, 0, 100 );
++    s=getenv( "INFINALITY_FT_USE_VARIOUS_TWEAKS" );
++    if( s ) _env.use_various_tweaks=bool_val( s );
++    s=getenv( "INFINALITY_FT_USE_KNOWN_SETTINGS_ON_SELECTED_FONTS" );
++    if( s ) _env.use_known_settings_on_selected_fonts=bool_val(s);
++#if(0)                          /* not used (naming error also) */
++    s=getenv( "INFINALITY_FT_AUTOHINT_MINIMUM_STEM_WIDTH" );
++    if( s ) _env.autohint_minimum_stem_height=int_val( s, 0, 100 );
++#endif
++    s=getenv( "INFINALITY_FT_STEM_SNAPPING_SLIDING_SCALE" );
++    if( s ) sscanf( s, "%d", &_env.stem_snapping_sliding_scale );
++    s=getenv( "INFINALITY_FT_STEM_ALIGNMENT_STRENGTH" );
++    if( s ) sscanf( s, "%d", &_env.stem_alignment_strength );
++    s=getenv( "INFINALITY_FT_STEM_DARKENING_AUTOFIT" );
++    if( s ) _env.stem_darkening_autofit=bool_val( s );
++    s=getenv( "INFINALITY_FT_STEM_DARKENING_CFF" );
++    if( s ) _env.stem_darkening_cff=bool_val( s );
++    s=getenv( "INFINALITY_FT_STEM_FITTING_STRENGTH" );
++    if( s ) sscanf( s, "%d", &_env.stem_fitting_strength );
++    s=getenv( "INFINALITY_FT_CHROMEOS_STYLE_SHARPENING_STRENGTH" );
++    if( s ) _env.chromeos_style_sharpening_strength=int_val( s, 0, 100 );
++    s=getenv( "INFINALITY_FT_BRIGHTNESS" );
++    if( s ) sscanf( s, "%d", &_env.brightness );
++    s=getenv( "INFINALITY_FT_CONTRAST" );
++    if( s ) sscanf( s, "%d", &_env.contrast );
++    s=getenv( "INFINALITY_FT_WINDOWS_STYLE_SHARPENING_STRENGTH" );
++    if( s ) _env.windows_style_sharpening_strength=int_val( s, 0, 100 );
++    s=getenv( "INFINALITY_FT_GAMMA_CORRECTION" );
++    if( s ){
++        float *f=_env.gamma_correction;
++        sscanf ( s, "%f %f", &f[0], &f[1] );
++        if( f[1] < 1.0f ) f[1]=1.0f;
++    }
++    s=getenv( "INFINALITY_FT_FRINGE_FILTER_STRENGTH" );
++    if( s ) sscanf( s, "%d", &_env.fringe_filter_strength );
++    s=getenv( "INFINALITY_FT_GRAYSCALE_FILTER_STRENGTH" );
++    if( s ) sscanf( s, "%d", &_env.grayscale_filter_strength );
++    s=getenv( "INFINALITY_FT_AUTOHINT_HORIZONTAL_STEM_DARKEN_STRENGTH" );
++    if( s ) sscanf( s, "%d", &_env.autohint_horizontal_stem_darken_strength );
++    s=getenv( "INFINALITY_FT_AUTOHINT_VERTICAL_STEM_DARKEN_STRENGTH" );
++    if( s ) sscanf( s, "%d", &_env.autohint_vertical_stem_darken_strength );
++    s=getenv( "INFINALITY_FT_GLOBAL_EMBOLDEN_X_VALUE" );
++    if( s ) sscanf( s, "%d", &_env.global_embolden_x_value );
++    s=getenv( "INFINALITY_FT_GLOBAL_EMBOLDEN_Y_VALUE" );
++    if( s ) sscanf( s, "%d", &_env.global_embolden_y_value );
++    s=getenv( "INFINALITY_FT_BOLD_EMBOLDEN_X_VALUE" );
++    if( s ) sscanf( s, "%d", &_env.bold_embolden_x_value );
++    s=getenv( "INFINALITY_FT_BOLD_EMBOLDEN_Y_VALUE" );
++    if( s ) sscanf( s, "%d", &_env.bold_embolden_y_value );
++    s=getenv( "INFINALITY_FT_FILTER_PARAMS" );
++    if( s ) {
++        int *f=_env.filter_params;
++        if( sscanf( s, "%d %d %d %d %d", f+1, f+2, f+3, f+4, f+5 )==5 )
++            f[0]=on;
++        else
++            f[0]=off;           /* FIXME: put a warning? */
++    }
++    /* do the range verifications as in original code */
++    if ( _env.stem_snapping_sliding_scale > maxp )
++        _env.stem_snapping_sliding_scale = 0;
++    else if ( _env.stem_snapping_sliding_scale < 0 )
++        _env.stem_snapping_sliding_scale = 0;
++    if (_env.stem_snapping_sliding_scale < 11 &&
++        _env.stem_snapping_sliding_scale > 0  )
++        _env.stem_snapping_sliding_scale = 11;
++
++    if ( _env.stem_alignment_strength > 100 )
++        _env.stem_alignment_strength = 100;
++    else if ( _env.stem_alignment_strength < 0 )
++        _env.stem_alignment_strength = 0;
++
++    if ( _env.stem_fitting_strength > 100 )
++        _env.stem_fitting_strength = 100;
++    else if ( _env.stem_fitting_strength < 0 )
++        _env.stem_fitting_strength = 0;
++
++    if ( _env.chromeos_style_sharpening_strength > 100 )
++        _env.chromeos_style_sharpening_strength = 100;
++    else if ( _env.chromeos_style_sharpening_strength < 0 )
++        _env.chromeos_style_sharpening_strength = 0;
++
++    if ( _env.brightness > 100 )
++        _env.brightness = 100;
++    else if ( _env.brightness < -100 )
++        _env.brightness = 0;
++
++    if ( _env.contrast > 100 )
++        _env.contrast = 100;
++    else if ( _env.contrast < -100 )
++        _env.contrast = 0;
++
++    if ( _env.windows_style_sharpening_strength > 100 )
++        _env.windows_style_sharpening_strength = 100;
++    else if ( _env.windows_style_sharpening_strength < 0 )
++        _env.windows_style_sharpening_strength = 0;
++
++    if ( _env.fringe_filter_strength > 100 )
++        _env.fringe_filter_strength = 100;
++    else if ( _env.fringe_filter_strength < 0 )
++        _env.fringe_filter_strength = 0;
++
++    if ( _env.grayscale_filter_strength > 100 )
++        _env.grayscale_filter_strength = 100;
++    else if ( _env.grayscale_filter_strength < 0 )
++        _env.grayscale_filter_strength = 0;
++
++    if ( _env.autohint_horizontal_stem_darken_strength > 100 )
++        _env.autohint_horizontal_stem_darken_strength = 100;
++    else if ( _env.autohint_horizontal_stem_darken_strength < 0 )
++        _env.autohint_horizontal_stem_darken_strength = 0;
++
++    if ( _env.autohint_vertical_stem_darken_strength > 100 )
++        _env.autohint_vertical_stem_darken_strength = 100;
++    else if ( _env.autohint_horizontal_stem_darken_strength < 0 )
++        _env.autohint_vertical_stem_darken_strength = 0;
++
++    if ( _env.global_embolden_x_value > 128 )
++        _env.global_embolden_x_value = 128;
++    else if ( _env.global_embolden_x_value < -128 )
++        _env.global_embolden_x_value = -128;
++
++    if ( _env.global_embolden_y_value > 128 )
++        _env.global_embolden_y_value = 128;
++    else if ( _env.global_embolden_y_value < -128 )
++          _env.global_embolden_y_value = -128;
++
++    if ( _env.bold_embolden_x_value > 128 )
++        _env.bold_embolden_x_value = 128;
++    else if (_env.bold_embolden_x_value < -128 )
++        _env.bold_embolden_x_value = -128;
++
++    if ( _env.bold_embolden_y_value > 128 )
++        _env.bold_embolden_y_value = 128;
++    else if ( _env.bold_embolden_y_value < -128 )
++        _env.bold_embolden_y_value = -128;
++
++    /* point to the combined and checked settings */
++    ftinf=&_env;
++}
+diff --git a/src/base/ftinf.h b/src/base/ftinf.h
+new file mode 100644
+index 0000000..fbe1bd1
+--- /dev/null
++++ b/src/base/ftinf.h
+@@ -0,0 +1,66 @@
++#ifndef _FTINF_H_
++#define _FTINF_H_
++/*
++    Stem snapping rules
++    (base freetype typedefs assumed already included)
++ */
++typedef struct
++{
++    FT_Int       stem_width;
++    FT_Int       stem_spacing;
++    FT_Int       stem_start;
++    FT_Int       stem_scaling;
++    FT_Int       stem_translating_only;
++    FT_Int       stem_translating;
++    float        brightness;
++    float        contrast;
++    FT_Bool      use_100;
++    FT_Bool      synth_stems;
++    FT_Bool      edge_detection;
++    FT_Bool      bearing_correction;
++    FT_Int       m;
++} Stem_Data;
++
++/*
++  Infinality settings
++ */
++typedef struct ftinf_s {
++    const char *name;
++    int autohint_horizontal_stem_darken_strength;
++    int autohint_snap_stem_height;
++    int autohint_increase_glyph_heights;
++    int autohint_vertical_stem_darken_strength;
++    int bold_embolden_x_value;
++    int bold_embolden_y_value;
++    int brightness;
++    int chromeos_style_sharpening_strength;
++    int contrast;
++    int filter_params[6];       /* 1st one used as existence flag */
++    int fringe_filter_strength;
++    float gamma_correction[2];
++    int global_embolden_x_value;
++    int global_embolden_y_value;
++    int grayscale_filter_strength;
++    int stem_alignment_strength;
++    int stem_darkening_autofit;
++    int stem_darkening_cff;
++    int stem_fitting_strength;
++    int stem_snapping_sliding_scale;
++    int use_known_settings_on_selected_fonts;
++    int use_various_tweaks;
++    int windows_style_sharpening_strength;
++} ftinf_t;
++
++extern FT_Pos infinality_cur_width; /* defined in aflatin.c */
++
++extern const ftinf_t *ftinf;    /* active settings */
++
++extern void ftinf_fill_stem_values( Stem_Data *stem_values,
++                                    const char *family, int ppem, int use_known );
++extern void ftinf_get_bc( const char *family, int ppem,
++                          float *brightness, float *contrast );
++
++/* get values from environment (FIXME: maybe update with using user files) */
++extern void ftinf_env();
++
++#endif
+diff --git a/src/base/ftinf_rh.c b/src/base/ftinf_rh.c
+new file mode 100644
+index 0000000..606b567
+--- /dev/null
++++ b/src/base/ftinf_rh.c
+@@ -0,0 +1,626 @@
++/* ANSI-C code produced by gperf version 3.1 */
++/* Command-line: gperf --output-file=ftinf_rh.c ftinf_rh.gperf  */
++/* Computed positions: -k'1,$' */
++
++#if !((' ' == 32) && ('!' == 33) && ('"' == 34) && ('#' == 35) \
++      && ('%' == 37) && ('&' == 38) && ('\'' == 39) && ('(' == 40) \
++      && (')' == 41) && ('*' == 42) && ('+' == 43) && (',' == 44) \
++      && ('-' == 45) && ('.' == 46) && ('/' == 47) && ('0' == 48) \
++      && ('1' == 49) && ('2' == 50) && ('3' == 51) && ('4' == 52) \
++      && ('5' == 53) && ('6' == 54) && ('7' == 55) && ('8' == 56) \
++      && ('9' == 57) && (':' == 58) && (';' == 59) && ('<' == 60) \
++      && ('=' == 61) && ('>' == 62) && ('?' == 63) && ('A' == 65) \
++      && ('B' == 66) && ('C' == 67) && ('D' == 68) && ('E' == 69) \
++      && ('F' == 70) && ('G' == 71) && ('H' == 72) && ('I' == 73) \
++      && ('J' == 74) && ('K' == 75) && ('L' == 76) && ('M' == 77) \
++      && ('N' == 78) && ('O' == 79) && ('P' == 80) && ('Q' == 81) \
++      && ('R' == 82) && ('S' == 83) && ('T' == 84) && ('U' == 85) \
++      && ('V' == 86) && ('W' == 87) && ('X' == 88) && ('Y' == 89) \
++      && ('Z' == 90) && ('[' == 91) && ('\\' == 92) && (']' == 93) \
++      && ('^' == 94) && ('_' == 95) && ('a' == 97) && ('b' == 98) \
++      && ('c' == 99) && ('d' == 100) && ('e' == 101) && ('f' == 102) \
++      && ('g' == 103) && ('h' == 104) && ('i' == 105) && ('j' == 106) \
++      && ('k' == 107) && ('l' == 108) && ('m' == 109) && ('n' == 110) \
++      && ('o' == 111) && ('p' == 112) && ('q' == 113) && ('r' == 114) \
++      && ('s' == 115) && ('t' == 116) && ('u' == 117) && ('v' == 118) \
++      && ('w' == 119) && ('x' == 120) && ('y' == 121) && ('z' == 122) \
++      && ('{' == 123) && ('|' == 124) && ('}' == 125) && ('~' == 126))
++/* The character set is not based on ISO-646.  */
++#error "gperf generated tables don't work with this execution character set. Please report a bug to <bug-gnu-gperf@gnu.org>."
++#endif
++
++#line 9 "ftinf_rh.gperf"
++
++#include <ctype.h>
++static const struct sa_rules_s* _rules_get( const char*str, unsigned len );
++/* maximum key range = 82, duplicates = 0 */
++
++#ifdef __GNUC__
++__inline
++#else
++#ifdef __cplusplus
++inline
++#endif
++#endif
++static unsigned int
++_rules_hash (register const char *str, register unsigned int len)
++{
++  static const unsigned char asso_values[] =
++    {
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85,  0, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85,  5, 45,  5,
++      35, 25, 35, 35, 50, 45, 85, 85,  0, 25,
++      40,  5,  0, 85, 50, 20, 20,  0, 10, 10,
++      85, 10, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
++      85, 85, 85, 85, 85, 85
++    };
++  return len + asso_values[(unsigned char)str[len - 1]] + asso_values[(unsigned char)str[0]];
++}
++
++#ifdef __GNUC__
++__inline
++#if defined __GNUC_STDC_INLINE__ || defined __GNUC_GNU_INLINE__
++__attribute__ ((__gnu_inline__))
++#endif
++#endif
++const struct sa_rules_s *
++_rules_get (register const char *str, register unsigned int len)
++{
++  enum
++    {
++      TOTAL_KEYWORDS = 58,
++      MIN_WORD_LENGTH = 3,
++      MAX_WORD_LENGTH = 24,
++      MIN_HASH_VALUE = 3,
++      MAX_HASH_VALUE = 84
++    };
++
++  static const struct sa_rules_s wordlist[] =
++    {
++#line 15 "ftinf_rh.gperf"
++{   .name="---",
++    .synthesize_stems={on, 13, 13, end}
++},
++#line 253 "ftinf_rh.gperf"
++{   .name="ubuntu",
++    .always_use_100={on, 12, 13, 15, 15, end}
++},
++#line 31 "ftinf_rh.gperf"
++{   .name="arial",
++    .always_use_100={on, 0, maxp, end},
++    .edge_detection={on, 11, 11, 13, 13, end},
++    .spacing={on, 10, 11, 23, 25, 30, end},
++    .start={on, 11, 18, 23, 30, 30, end},
++    .stem_translating={on, 11, 32, end},
++    .stem_translating_only={on, 10, 16, 8, 32, 9, 32, 16, -24, end}
++},
++#line 87 "ftinf_rh.gperf"
++{   .name="corbel",
++    .stem_translating_only={on, 10, 16, end},
++    .stem_widths={on, 10, 21, maxp}
++},
++#line 71 "ftinf_rh.gperf"
++{   .name="canwell",
++    .stem_scaling={on, 13, 0, end}
++},
++#line 216 "ftinf_rh.gperf"
++{   .name="pragmata",
++    .always_use_100={on, 0, maxp, end}
++},
++#line 67 "ftinf_rh.gperf"
++{   .name="cantarell",
++    .stem_translating_only={on, 11, 0, 12, 0, end},
++    .stem_widths={on, 10, 22, maxp,}
++},
++#line 39 "ftinf_rh.gperf"
++{   .name="arimo",
++    .always_use_100={on, 0, maxp, end},
++    .stem_translating={on, 11, 32, end},
++    .stem_translating_only={on, 10, 8, 8, 32, 9, 32, end}
++},
++#line 207 "ftinf_rh.gperf"
++{   .name="optima",
++    .brightness={on, 0, -20, end},
++    .contrast={on, 0, 25, end},
++    .stem_scaling={on, 17, 1, end},
++    .stem_translating_only={on, 10, 0, 11, 0, 12, 0, end}
++},
++#line 63 "ftinf_rh.gperf"
++{   .name="candara",
++    .stem_scaling={on, 14, 1, 17, 1, end},
++    .stem_translating_only={on, 10, 16, end}
++},
++#line 77 "ftinf_rh.gperf"
++{   .name="comfortaa",
++    .stem_widths={on, 10, 19, 22, maxp},
++    .stem_scaling={on, 11, 0, end}
++},
++#line 161 "ftinf_rh.gperf"
++{   .name="liberation mono",
++    .always_use_100={on, 0, maxp, end}
++},
++#line 18 "ftinf_rh.gperf"
++{   .name="andale mono",
++    .always_use_100={on, 0, maxp, end},
++    .stem_scaling={on, 11, 1, end},
++    .stem_widths={on, 10, 21, maxp,}
++},
++#line 256 "ftinf_rh.gperf"
++{   .name="verdana",
++    .always_use_100={on, 0, 14, 16, maxp, end},
++    .stem_scaling={on, 12, 1, 15, 1, end},
++    .stem_translating_only={on, 8, 16, 15, 16, 14, 32, 18, 32, 19, 24, end}
++},
++#line 74 "ftinf_rh.gperf"
++{   .name="century gothic",
++    .stem_widths={on, 10, 22, maxp,}
++},
++#line 91 "ftinf_rh.gperf"
++{   .name="courier new",
++    .always_use_100={on, 12, 12, end},
++    .edge_detection={on, 10, 12, end},
++    .m={on, 13, 1, 14, 1, end}
++},
++#line 23 "ftinf_rh.gperf"
++{   .name="arial narrow",
++    .stem_widths={on, 10, 21, maxp,}
++},
++#line 185 "ftinf_rh.gperf"
++{   .name="luxi sans",
++    .always_use_100={on, 13, 13, end},
++    .stem_widths={on, 10, 17, sw2pv, maxp,}
++},
++#line 225 "ftinf_rh.gperf"
++{   .name="samba",
++    .stem_scaling={on, 11, 0, end}
++},
++#line 233 "ftinf_rh.gperf"
++{   .name="tahoma",
++    .always_use_100={on, 11, 11, 14, maxp, end},
++    .edge_detection={on, 11, 11, end},
++    .spacing={on, 10, 12, 18, 18, 30, end},
++    .start={on, 14, 17, 30, 100, 100, end},
++    .stem_translating={on, 11, 32, end},
++    .stem_translating_only={on, 7, 32, 8, 32, 9, 32, end},
++},
++#line 164 "ftinf_rh.gperf"
++{   .name="liberation sans narrow",
++    .stem_widths={on,10, 22, maxp,}
++},
++#line 81 "ftinf_rh.gperf"
++{   .name="consolas",
++    .always_use_100={on, 0, maxp, end},
++    .stem_translating_only={on, 8, 32, 9, 32, end},
++    .stem_widths={on, 10, 20, maxp,},
++    .stem_scaling={on, 11, 1, end}
++},
++#line 203 "ftinf_rh.gperf"
++{   .name="open sans",
++    .stem_translating_only={on, 10, 16, 9, 16, end},
++    .stem_widths={on, 10, 20, maxp,}
++},
++#line 167 "ftinf_rh.gperf"
++{   .name="liberation sans",
++    .edge_detection={on, 11, 11, end},
++    .stem_translating={on, 11, 32, end},
++    .stem_translating_only={on, 10, 8, 8, 32, 9, 32, end},
++    .stem_widths={on,10, 19, maxp,}
++},
++#line 193 "ftinf_rh.gperf"
++{   .name="monaco",
++    .always_use_100={on, 0, maxp, end}
++},
++#line 101 "ftinf_rh.gperf"
++{   .name="cousine",
++    .always_use_100={on, 0, maxp, end}
++},
++#line 176 "ftinf_rh.gperf"
++{   .name="lucida grande",
++    .stem_scaling={on, 13, 1, end},
++    .stem_translating_only={on, 13, 24, 14, 24, 8, 16, 9, 16, end},
++    .stem_widths={on, 10, 16, sw2pv, maxp},
++},
++#line 173 "ftinf_rh.gperf"
++{   .name="lucida console",
++    .always_use_100={on, 0, maxp, end}
++},
++#line 196 "ftinf_rh.gperf"
++{   .name="myriad pro",
++    .stem_scaling={on, 14, 1, 17, 1, end},
++    .stem_translating_only={on, 10, 16, 11, 0, 9, 16, end}
++},
++#line 26 "ftinf_rh.gperf"
++{   .name="arial unicode ms",
++    .always_use_100={on, 0, maxp, end},
++    .stem_translating={on, 11, 32, end},
++    .stem_translating_only={on, 10, 16, 8, 32, 9, 32, end}
++},
++#line 213 "ftinf_rh.gperf"
++{   .name="palatino linotype",
++    .edge_detection={on, 0, 100, end}
++},
++#line 181 "ftinf_rh.gperf"
++{   .name="lucida sans unicode",
++    .stem_translating_only={on, 13, 24, 14, 24, 8, 16, 9, 16, end},
++    .stem_widths={on,10, 16, sw2pv, maxp,}
++},
++#line 140 "ftinf_rh.gperf"
++{   .name="futura",
++    .stem_widths={on, 10, 14, sw2pv, maxp,}
++},
++#line 147 "ftinf_rh.gperf"
++{   .name="georgia",
++    .stem_translating_only={on, 13, 16, 14, 16, 15, 0, end}
++},
++#line 125 "ftinf_rh.gperf"
++{   .name="freemono",
++    .always_use_100={on, 0, maxp, end}
++},
++#line 200 "ftinf_rh.gperf"
++{   .name="nina",
++    .stem_scaling={on, 11, 0, 12, 0, 13, 0, end}
++},
++#line 121 "ftinf_rh.gperf"
++{   .name="essential pragmatapro",
++    .always_use_100={on, 0, maxp, end},
++    .m={on, 13, 0, 14, 0, end}
++},
++#line 247 "ftinf_rh.gperf"
++{   .name="trebuchet ms",
++    .always_use_100={on, 13, 13, end},
++    .stem_scaling={on, 13, 0, 17, 0, 20, 1, end},
++    .stem_translating_only={on, 10, 16, 11, 0, 8, 32, 9, 32, end},
++    .stem_widths={on, 10, 17, sw2pv, maxp,}
++},
++#line 114 "ftinf_rh.gperf"
++{   .name="droid sans mono",
++    .m={on, 12, 0, end}
++},
++#line 104 "ftinf_rh.gperf"
++{   .name="dejavu sans mono",
++    .always_use_100={on, 0, maxp, end},
++    .stem_translating_only={on, 7, 16, 8, 32, 9, 16, end}
++},
++#line 57 "ftinf_rh.gperf"
++{   .name="calibri",
++    .always_use_100={on, 23, maxp, end},
++    .stem_scaling={on, 15, 1, 17, 1, 18, 1, end},
++    .stem_translating_only={on, 10, 16, 15, 0, end},
++    .stem_widths={on, 1, 10, 19, maxp,}
++},
++#line 156 "ftinf_rh.gperf"
++{   .name="inconsolata",
++    .stem_scaling={on, 12, 1, 15, 1, end},
++    .stem_translating_only={on, 10, 24, 9, 32, end},
++    .stem_widths={on, 10, 23, maxp,},
++},
++#line 96 "ftinf_rh.gperf"
++{   .name="courier",
++    .always_use_100={on, 0, maxp, end},
++    .m={on, 13, 1, 14, 1, end},
++    .stem_translating_only={on, 13, 16, 15, 0, end}
++},
++#line 128 "ftinf_rh.gperf"
++{   .name="freesans",
++    .always_use_100={on, 0, maxp, end},
++    .edge_detection={on, 11, 11, 13, 13, end},
++    .spacing={on, 10, 12, 18, 18, 30, end},
++    .start={on, 10, 18, 18, 25, 30, end},
++    .stem_scaling={on, 16, 0, end},
++    .stem_translating={on, 11, 32, end},
++    .stem_translating_only={on, 10, 16, 9, 8, end}
++},
++#line 150 "ftinf_rh.gperf"
++{   .name="gill sans",
++    .stem_widths={on, 10, 17, sw2pv, maxp,}
++},
++#line 117 "ftinf_rh.gperf"
++{   .name="droid sans",
++    .always_use_100={on, 12, 12, 15, 15, end},
++    .stem_translating_only={on, 8, 16, 9, 16, end}
++},
++#line 108 "ftinf_rh.gperf"
++{   .name="dejavu sans",
++    .always_use_100={on, 10, 14, 16, 17, end},
++    .m={on, 12, 0, end},
++    .stem_scaling={on, 12, 1, end},
++    .stem_translating_only={on, 8, 16, 15, -20, end}
++},
++#line 219 "ftinf_rh.gperf"
++{   .name="raleway",
++    .stem_scaling={on, 15, 0, end}
++},
++#line 153 "ftinf_rh.gperf"
++{   .name="helvetica cy",
++    .stem_widths={on, 10, 23, maxp,}
++},
++#line 228 "ftinf_rh.gperf"
++{   .name="segoe ui",
++    .always_use_100={on, 11, 12, 14, 14, end},
++    .stem_translating_only={on, 10, 0, 7, 32, 8, 16, 9, 24, end},
++    .stem_widths={on, 10, 23, maxp,}
++},
++#line 48 "ftinf_rh.gperf"
++{   .name="bitstream vera sans mono",
++    .always_use_100={on, 0, maxp, end}
++},
++#line 241 "ftinf_rh.gperf"
++{   .name="times new roman",
++    .always_use_100={on, 14, 14, 16, 16, end},
++    .bearing_correction={0, 100, end},
++    .stem_scaling={on, 17, 1, end},
++    .stem_translating_only={on, 17, 8, end}
++},
++#line 222 "ftinf_rh.gperf"
++{   .name="rokkitt",
++    .stem_widths={on, 10, 21, maxp,}
++},
++#line 143 "ftinf_rh.gperf"
++{   .name="garamond",
++    .brightness={on, 0, -20, end},
++    .contrast={on, 0, 25, end}
++},
++#line 137 "ftinf_rh.gperf"
++{   .name="freeserif",
++    .stem_scaling={on, 13, 1, 17, 1, end}
++},
++#line 189 "ftinf_rh.gperf"
++{   .name="microsoft sans serif",
++    .always_use_100={on, 0, maxp, end},
++    .stem_translating_only={on, 10, 16, 8, 32, 9, 32, end}
++},
++#line 44 "ftinf_rh.gperf"
++{   .name="baskerville",
++    .brightness={on, 0, -20, end},
++    .contrast={on, 0, 25, end}
++},
++#line 51 "ftinf_rh.gperf"
++{   .name="bitstream vera sans",
++    .always_use_100={on, 10, 14, 16, 17, end},
++    .m={on, 12, 0, end},
++    .stem_scaling={on ,12, 1, end},
++    .stem_translating_only={on, 8, 16, end}
++}
++    };
++
++  if (len <= MAX_WORD_LENGTH && len >= MIN_WORD_LENGTH)
++    {
++      register int key = _rules_hash (str, len);
++
++      if (key <= MAX_HASH_VALUE && key >= MIN_HASH_VALUE)
++        {
++          register const struct sa_rules_s *resword;
++
++          switch (key - 3)
++            {
++              case 0:
++                resword = &wordlist[0];
++                goto compare;
++              case 3:
++                resword = &wordlist[1];
++                goto compare;
++              case 7:
++                resword = &wordlist[2];
++                goto compare;
++              case 8:
++                resword = &wordlist[3];
++                goto compare;
++              case 9:
++                resword = &wordlist[4];
++                goto compare;
++              case 10:
++                resword = &wordlist[5];
++                goto compare;
++              case 11:
++                resword = &wordlist[6];
++                goto compare;
++              case 12:
++                resword = &wordlist[7];
++                goto compare;
++              case 13:
++                resword = &wordlist[8];
++                goto compare;
++              case 14:
++                resword = &wordlist[9];
++                goto compare;
++              case 16:
++                resword = &wordlist[10];
++                goto compare;
++              case 17:
++                resword = &wordlist[11];
++                goto compare;
++              case 18:
++                resword = &wordlist[12];
++                goto compare;
++              case 19:
++                resword = &wordlist[13];
++                goto compare;
++              case 21:
++                resword = &wordlist[14];
++                goto compare;
++              case 23:
++                resword = &wordlist[15];
++                goto compare;
++              case 24:
++                resword = &wordlist[16];
++                goto compare;
++              case 26:
++                resword = &wordlist[17];
++                goto compare;
++              case 27:
++                resword = &wordlist[18];
++                goto compare;
++              case 28:
++                resword = &wordlist[19];
++                goto compare;
++              case 29:
++                resword = &wordlist[20];
++                goto compare;
++              case 30:
++                resword = &wordlist[21];
++                goto compare;
++              case 31:
++                resword = &wordlist[22];
++                goto compare;
++              case 32:
++                resword = &wordlist[23];
++                goto compare;
++              case 33:
++                resword = &wordlist[24];
++                goto compare;
++              case 34:
++                resword = &wordlist[25];
++                goto compare;
++              case 35:
++                resword = &wordlist[26];
++                goto compare;
++              case 36:
++                resword = &wordlist[27];
++                goto compare;
++              case 37:
++                resword = &wordlist[28];
++                goto compare;
++              case 38:
++                resword = &wordlist[29];
++                goto compare;
++              case 39:
++                resword = &wordlist[30];
++                goto compare;
++              case 41:
++                resword = &wordlist[31];
++                goto compare;
++              case 43:
++                resword = &wordlist[32];
++                goto compare;
++              case 44:
++                resword = &wordlist[33];
++                goto compare;
++              case 45:
++                resword = &wordlist[34];
++                goto compare;
++              case 46:
++                resword = &wordlist[35];
++                goto compare;
++              case 48:
++                resword = &wordlist[36];
++                goto compare;
++              case 49:
++                resword = &wordlist[37];
++                goto compare;
++              case 52:
++                resword = &wordlist[38];
++                goto compare;
++              case 53:
++                resword = &wordlist[39];
++                goto compare;
++              case 54:
++                resword = &wordlist[40];
++                goto compare;
++              case 58:
++                resword = &wordlist[41];
++                goto compare;
++              case 59:
++                resword = &wordlist[42];
++                goto compare;
++              case 60:
++                resword = &wordlist[43];
++                goto compare;
++              case 61:
++                resword = &wordlist[44];
++                goto compare;
++              case 62:
++                resword = &wordlist[45];
++                goto compare;
++              case 63:
++                resword = &wordlist[46];
++                goto compare;
++              case 64:
++                resword = &wordlist[47];
++                goto compare;
++              case 69:
++                resword = &wordlist[48];
++                goto compare;
++              case 70:
++                resword = &wordlist[49];
++                goto compare;
++              case 71:
++                resword = &wordlist[50];
++                goto compare;
++              case 72:
++                resword = &wordlist[51];
++                goto compare;
++              case 74:
++                resword = &wordlist[52];
++                goto compare;
++              case 75:
++                resword = &wordlist[53];
++                goto compare;
++              case 76:
++                resword = &wordlist[54];
++                goto compare;
++              case 77:
++                resword = &wordlist[55];
++                goto compare;
++              case 78:
++                resword = &wordlist[56];
++                goto compare;
++              case 81:
++                resword = &wordlist[57];
++                goto compare;
++            }
++          return 0;
++        compare:
++          {
++            register const char *s = resword->name;
++
++            if (*str == *s && !strcmp (str + 1, s + 1))
++              return resword;
++          }
++        }
++    }
++  return 0;
++}
++#line 261 "ftinf_rh.gperf"
++
++
++static const sa_rules_t*
++ftinf_rules( const char *name ){
++    if( name ){
++        enum {
++            max_wlen=31
++        };
++        char buf[max_wlen+1];
++        int len=strlen( name );
++        if( len <= max_wlen ){
++            int i;
++            for( i=0; i<len; ++i )
++                buf[i]=tolower( name[i] );
++            buf[len]='\0';
++            return _rules_get( buf, len );
++        }
++    }
++    return NULL;
++}
++/*
++   gperf --output-file=ftinf_rh.c ftinf_rh.gperf
++*/
+diff --git a/src/base/ftinf_rh.gperf b/src/base/ftinf_rh.gperf
+new file mode 100644
+index 0000000..9fd8aab
+--- /dev/null
++++ b/src/base/ftinf_rh.gperf
+@@ -0,0 +1,283 @@
++%struct-type
++%define slot-name name
++%enum
++%switch=1
++%readonly-tables
++%omit-struct-type
++%define lookup-function-name  _rules_get
++%define hash-function-name _rules_hash
++%{
++#include <ctype.h>
++static const struct sa_rules_s* _rules_get( const char*str, unsigned len );
++%}
++struct sa_rules_s;
++%%
++{   .name="---",
++    .synthesize_stems={on, 13, 13, end}
++},
++{   .name="andale mono",
++    .always_use_100={on, 0, maxp, end},
++    .stem_scaling={on, 11, 1, end},
++    .stem_widths={on, 10, 21, maxp,}
++},
++{   .name="arial narrow",
++    .stem_widths={on, 10, 21, maxp,}
++},
++{   .name="arial unicode ms",
++    .always_use_100={on, 0, maxp, end},
++    .stem_translating={on, 11, 32, end},
++    .stem_translating_only={on, 10, 16, 8, 32, 9, 32, end}
++},
++{   .name="arial",
++    .always_use_100={on, 0, maxp, end},
++    .edge_detection={on, 11, 11, 13, 13, end},
++    .spacing={on, 10, 11, 23, 25, 30, end},
++    .start={on, 11, 18, 23, 30, 30, end},
++    .stem_translating={on, 11, 32, end},
++    .stem_translating_only={on, 10, 16, 8, 32, 9, 32, 16, -24, end}
++},
++{   .name="arimo",
++    .always_use_100={on, 0, maxp, end},
++    .stem_translating={on, 11, 32, end},
++    .stem_translating_only={on, 10, 8, 8, 32, 9, 32, end}
++},
++{   .name="baskerville",
++    .brightness={on, 0, -20, end},
++    .contrast={on, 0, 25, end}
++},
++{   .name="bitstream vera sans mono",
++    .always_use_100={on, 0, maxp, end}
++},
++{   .name="bitstream vera sans",
++    .always_use_100={on, 10, 14, 16, 17, end},
++    .m={on, 12, 0, end},
++    .stem_scaling={on ,12, 1, end},
++    .stem_translating_only={on, 8, 16, end}
++},
++{   .name="calibri",
++    .always_use_100={on, 23, maxp, end},
++    .stem_scaling={on, 15, 1, 17, 1, 18, 1, end},
++    .stem_translating_only={on, 10, 16, 15, 0, end},
++    .stem_widths={on, 1, 10, 19, maxp,}
++},
++{   .name="candara",
++    .stem_scaling={on, 14, 1, 17, 1, end},
++    .stem_translating_only={on, 10, 16, end}
++},
++{   .name="cantarell",
++    .stem_translating_only={on, 11, 0, 12, 0, end},
++    .stem_widths={on, 10, 22, maxp,}
++},
++{   .name="canwell",
++    .stem_scaling={on, 13, 0, end}
++},
++{   .name="century gothic",
++    .stem_widths={on, 10, 22, maxp,}
++},
++{   .name="comfortaa",
++    .stem_widths={on, 10, 19, 22, maxp},
++    .stem_scaling={on, 11, 0, end}
++},
++{   .name="consolas",
++    .always_use_100={on, 0, maxp, end},
++    .stem_translating_only={on, 8, 32, 9, 32, end},
++    .stem_widths={on, 10, 20, maxp,},
++    .stem_scaling={on, 11, 1, end}
++},
++{   .name="corbel",
++    .stem_translating_only={on, 10, 16, end},
++    .stem_widths={on, 10, 21, maxp}
++},
++{   .name="courier new",
++    .always_use_100={on, 12, 12, end},
++    .edge_detection={on, 10, 12, end},
++    .m={on, 13, 1, 14, 1, end}
++},
++{   .name="courier",
++    .always_use_100={on, 0, maxp, end},
++    .m={on, 13, 1, 14, 1, end},
++    .stem_translating_only={on, 13, 16, 15, 0, end}
++},
++{   .name="cousine",
++    .always_use_100={on, 0, maxp, end}
++},
++{   .name="dejavu sans mono",
++    .always_use_100={on, 0, maxp, end},
++    .stem_translating_only={on, 7, 16, 8, 32, 9, 16, end}
++},
++{   .name="dejavu sans",
++    .always_use_100={on, 10, 14, 16, 17, end},
++    .m={on, 12, 0, end},
++    .stem_scaling={on, 12, 1, end},
++    .stem_translating_only={on, 8, 16, 15, -20, end}
++},
++{   .name="droid sans mono",
++    .m={on, 12, 0, end}
++},
++{   .name="droid sans",
++    .always_use_100={on, 12, 12, 15, 15, end},
++    .stem_translating_only={on, 8, 16, 9, 16, end}
++},
++{   .name="essential pragmatapro",
++    .always_use_100={on, 0, maxp, end},
++    .m={on, 13, 0, 14, 0, end}
++},
++{   .name="freemono",
++    .always_use_100={on, 0, maxp, end}
++},
++{   .name="freesans",
++    .always_use_100={on, 0, maxp, end},
++    .edge_detection={on, 11, 11, 13, 13, end},
++    .spacing={on, 10, 12, 18, 18, 30, end},
++    .start={on, 10, 18, 18, 25, 30, end},
++    .stem_scaling={on, 16, 0, end},
++    .stem_translating={on, 11, 32, end},
++    .stem_translating_only={on, 10, 16, 9, 8, end}
++},
++{   .name="freeserif",
++    .stem_scaling={on, 13, 1, 17, 1, end}
++},
++{   .name="futura",
++    .stem_widths={on, 10, 14, sw2pv, maxp,}
++},
++{   .name="garamond",
++    .brightness={on, 0, -20, end},
++    .contrast={on, 0, 25, end}
++},
++{   .name="georgia",
++    .stem_translating_only={on, 13, 16, 14, 16, 15, 0, end}
++},
++{   .name="gill sans",
++    .stem_widths={on, 10, 17, sw2pv, maxp,}
++},
++{   .name="helvetica cy",
++    .stem_widths={on, 10, 23, maxp,}
++},
++{   .name="inconsolata",
++    .stem_scaling={on, 12, 1, 15, 1, end},
++    .stem_translating_only={on, 10, 24, 9, 32, end},
++    .stem_widths={on, 10, 23, maxp,},
++},
++{   .name="liberation mono",
++    .always_use_100={on, 0, maxp, end}
++},
++{   .name="liberation sans narrow",
++    .stem_widths={on,10, 22, maxp,}
++},
++{   .name="liberation sans",
++    .edge_detection={on, 11, 11, end},
++    .stem_translating={on, 11, 32, end},
++    .stem_translating_only={on, 10, 8, 8, 32, 9, 32, end},
++    .stem_widths={on,10, 19, maxp,}
++},
++{   .name="lucida console",
++    .always_use_100={on, 0, maxp, end}
++},
++{   .name="lucida grande",
++    .stem_scaling={on, 13, 1, end},
++    .stem_translating_only={on, 13, 24, 14, 24, 8, 16, 9, 16, end},
++    .stem_widths={on, 10, 16, sw2pv, maxp},
++},
++{   .name="lucida sans unicode",
++    .stem_translating_only={on, 13, 24, 14, 24, 8, 16, 9, 16, end},
++    .stem_widths={on,10, 16, sw2pv, maxp,}
++},
++{   .name="luxi sans",
++    .always_use_100={on, 13, 13, end},
++    .stem_widths={on, 10, 17, sw2pv, maxp,}
++},
++{   .name="microsoft sans serif",
++    .always_use_100={on, 0, maxp, end},
++    .stem_translating_only={on, 10, 16, 8, 32, 9, 32, end}
++},
++{   .name="monaco",
++    .always_use_100={on, 0, maxp, end}
++},
++{   .name="myriad pro",
++    .stem_scaling={on, 14, 1, 17, 1, end},
++    .stem_translating_only={on, 10, 16, 11, 0, 9, 16, end}
++},
++{   .name="nina",
++    .stem_scaling={on, 11, 0, 12, 0, 13, 0, end}
++},
++{   .name="open sans",
++    .stem_translating_only={on, 10, 16, 9, 16, end},
++    .stem_widths={on, 10, 20, maxp,}
++},
++{   .name="optima",
++    .brightness={on, 0, -20, end},
++    .contrast={on, 0, 25, end},
++    .stem_scaling={on, 17, 1, end},
++    .stem_translating_only={on, 10, 0, 11, 0, 12, 0, end}
++},
++{   .name="palatino linotype",
++    .edge_detection={on, 0, 100, end}
++},
++{   .name="pragmata",
++    .always_use_100={on, 0, maxp, end}
++},
++{   .name="raleway",
++    .stem_scaling={on, 15, 0, end}
++},
++{   .name="rokkitt",
++    .stem_widths={on, 10, 21, maxp,}
++},
++{   .name="samba",
++    .stem_scaling={on, 11, 0, end}
++},
++{   .name="segoe ui",
++    .always_use_100={on, 11, 12, 14, 14, end},
++    .stem_translating_only={on, 10, 0, 7, 32, 8, 16, 9, 24, end},
++    .stem_widths={on, 10, 23, maxp,}
++},
++{   .name="tahoma",
++    .always_use_100={on, 11, 11, 14, maxp, end},
++    .edge_detection={on, 11, 11, end},
++    .spacing={on, 10, 12, 18, 18, 30, end},
++    .start={on, 14, 17, 30, 100, 100, end},
++    .stem_translating={on, 11, 32, end},
++    .stem_translating_only={on, 7, 32, 8, 32, 9, 32, end},
++},
++{   .name="times new roman",
++    .always_use_100={on, 14, 14, 16, 16, end},
++    .bearing_correction={0, 100, end},
++    .stem_scaling={on, 17, 1, end},
++    .stem_translating_only={on, 17, 8, end}
++},
++{   .name="trebuchet ms",
++    .always_use_100={on, 13, 13, end},
++    .stem_scaling={on, 13, 0, 17, 0, 20, 1, end},
++    .stem_translating_only={on, 10, 16, 11, 0, 8, 32, 9, 32, end},
++    .stem_widths={on, 10, 17, sw2pv, maxp,}
++},
++{   .name="ubuntu",
++    .always_use_100={on, 12, 13, 15, 15, end}
++},
++{   .name="verdana",
++    .always_use_100={on, 0, 14, 16, maxp, end},
++    .stem_scaling={on, 12, 1, 15, 1, end},
++    .stem_translating_only={on, 8, 16, 15, 16, 14, 32, 18, 32, 19, 24, end}
++},
++%%
++
++static const sa_rules_t*
++ftinf_rules( const char *name ){
++    if( name ){
++        enum {
++            max_wlen=31
++        };
++        char buf[max_wlen+1];
++        int len=strlen( name );
++        if( len <= max_wlen ){
++            int i;
++            for( i=0; i<len; ++i )
++                buf[i]=tolower( name[i] );
++            buf[len]='\0';
++            return _rules_get( buf, len );
++        }
++    }
++    return NULL;
++}
++/*
++   gperf --output-file=ftinf_rh.c ftinf_rh.gperf
++*/
+diff --git a/src/base/ftinf_sh.c b/src/base/ftinf_sh.c
+new file mode 100644
+index 0000000..87d2ff8
+--- /dev/null
++++ b/src/base/ftinf_sh.c
+@@ -0,0 +1,463 @@
++/* ANSI-C code produced by gperf version 3.1 */
++/* Command-line: gperf --output-file=ftinf_sh.c ftinf_sh.gperf  */
++/* Computed positions: -k'1,$' */
++
++#if !((' ' == 32) && ('!' == 33) && ('"' == 34) && ('#' == 35) \
++      && ('%' == 37) && ('&' == 38) && ('\'' == 39) && ('(' == 40) \
++      && (')' == 41) && ('*' == 42) && ('+' == 43) && (',' == 44) \
++      && ('-' == 45) && ('.' == 46) && ('/' == 47) && ('0' == 48) \
++      && ('1' == 49) && ('2' == 50) && ('3' == 51) && ('4' == 52) \
++      && ('5' == 53) && ('6' == 54) && ('7' == 55) && ('8' == 56) \
++      && ('9' == 57) && (':' == 58) && (';' == 59) && ('<' == 60) \
++      && ('=' == 61) && ('>' == 62) && ('?' == 63) && ('A' == 65) \
++      && ('B' == 66) && ('C' == 67) && ('D' == 68) && ('E' == 69) \
++      && ('F' == 70) && ('G' == 71) && ('H' == 72) && ('I' == 73) \
++      && ('J' == 74) && ('K' == 75) && ('L' == 76) && ('M' == 77) \
++      && ('N' == 78) && ('O' == 79) && ('P' == 80) && ('Q' == 81) \
++      && ('R' == 82) && ('S' == 83) && ('T' == 84) && ('U' == 85) \
++      && ('V' == 86) && ('W' == 87) && ('X' == 88) && ('Y' == 89) \
++      && ('Z' == 90) && ('[' == 91) && ('\\' == 92) && (']' == 93) \
++      && ('^' == 94) && ('_' == 95) && ('a' == 97) && ('b' == 98) \
++      && ('c' == 99) && ('d' == 100) && ('e' == 101) && ('f' == 102) \
++      && ('g' == 103) && ('h' == 104) && ('i' == 105) && ('j' == 106) \
++      && ('k' == 107) && ('l' == 108) && ('m' == 109) && ('n' == 110) \
++      && ('o' == 111) && ('p' == 112) && ('q' == 113) && ('r' == 114) \
++      && ('s' == 115) && ('t' == 116) && ('u' == 117) && ('v' == 118) \
++      && ('w' == 119) && ('x' == 120) && ('y' == 121) && ('z' == 122) \
++      && ('{' == 123) && ('|' == 124) && ('}' == 125) && ('~' == 126))
++/* The character set is not based on ISO-646.  */
++#error "gperf generated tables don't work with this execution character set. Please report a bug to <bug-gnu-gperf@gnu.org>."
++#endif
++
++#line 9 "ftinf_sh.gperf"
++
++#include <ctype.h>
++static const struct ftinf_s* _settings_get( const char*str, unsigned len);
++/* maximum key range = 37, duplicates = 0 */
++
++#ifdef __GNUC__
++__inline
++#else
++#ifdef __cplusplus
++inline
++#endif
++#endif
++static unsigned int
++_settings_hash (register const char *str, register unsigned int len)
++{
++  static const unsigned char asso_values[] =
++    {
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 13,
++       8, 30, 25, 20, 40, 10, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40,  5, 40,  0,
++       0,  0, 40, 40, 10,  0, 40, 40, 15,  5,
++      10,  0, 10, 40, 40,  0,  0,  0,  0,  0,
++       0,  0, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
++      40, 40, 40, 40, 40, 40
++    };
++  return len + asso_values[(unsigned char)str[len - 1]] + asso_values[(unsigned char)str[0]];
++}
++
++#ifdef __GNUC__
++__inline
++#if defined __GNUC_STDC_INLINE__ || defined __GNUC_GNU_INLINE__
++__attribute__ ((__gnu_inline__))
++#endif
++#endif
++const struct ftinf_s *
++_settings_get (register const char *str, register unsigned int len)
++{
++  enum
++    {
++      TOTAL_KEYWORDS = 22,
++      MIN_WORD_LENGTH = 3,
++      MAX_WORD_LENGTH = 14,
++      MIN_HASH_VALUE = 3,
++      MAX_HASH_VALUE = 39
++    };
++
++  static const struct ftinf_s wordlist[] =
++    {
++#line 76 "ftinf_sh.gperf"
++{   .name="osx",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_vertical_stem_darken_strength=25,
++    .bold_embolden_x_value=16,
++    .brightness=10,
++    .contrast=20,
++    .filter_params={on, 3, 32, 38, 32, 3},
++    .gamma_correction={1000, 80},
++    .global_embolden_y_value=8,
++    .grayscale_filter_strength=25,
++},
++#line 37 "ftinf_sh.gperf"
++{   .name="ipad",
++    .filter_params={on, 0, 0, 100, 0, 0},
++    .gamma_correction={1000, 80},
++    .grayscale_filter_strength=100
++},
++#line 114 "ftinf_sh.gperf"
++{   .name="shove",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_increase_glyph_heights=true,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .filter_params={on, 11, 22, 38, 22, 11},
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=100,
++    .stem_fitting_strength=100,
++    .use_known_settings_on_selected_fonts=true,
++    .use_various_tweaks=true
++},
++#line 126 "ftinf_sh.gperf"
++{   .name="ubuntu",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_vertical_stem_darken_strength=25,
++    .brightness=-10,
++    .contrast=15,
++    .filter_params={on, 11, 22, 38, 22, 11},
++    .gamma_correction={1000, 80},
++    .use_various_tweaks=true
++},
++#line 27 "ftinf_sh.gperf"
++{   .name="classic",
++    .autohint_increase_glyph_heights=true,
++    .autohint_snap_stem_height=100,
++    .filter_params={on, 6, 25, 38, 25, 6},
++    .gamma_correction={0, 100},
++    .use_various_tweaks=true
++},
++#line 34 "ftinf_sh.gperf"
++{   .name="disabled",
++    .gamma_correction={0, 100},
++},
++#line 100 "ftinf_sh.gperf"
++{   .name="sharpened",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_increase_glyph_heights=true,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .filter_params={on, 11, 22, 38, 22, 11},
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=25,
++    .stem_fitting_strength=25,
++    .stem_snapping_sliding_scale=40,
++    .use_known_settings_on_selected_fonts=true,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=65
++},
++#line 42 "ftinf_sh.gperf"
++{   .name="infinality",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_increase_glyph_heights=true,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .filter_params={on, 11, 22, 38, 22, 11},
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=25,
++    .stem_fitting_strength=25,
++    .stem_snapping_sliding_scale=40,
++    .use_known_settings_on_selected_fonts=true,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=5
++},
++#line 15 "ftinf_sh.gperf"
++{   .name="custom",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .filter_params={on, 8, 24, 48, 24, 8},
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=75,
++    .stem_fitting_strength=50,
++    .stem_snapping_sliding_scale=30,
++    .use_known_settings_on_selected_fonts=true,
++    .use_various_tweaks=true
++},
++#line 180 "ftinf_sh.gperf"
++{   .name="vanilla",
++    .filter_params={on, 6, 25, 38, 25, 6},
++    .gamma_correction={0, 100},
++},
++#line 184 "ftinf_sh.gperf"
++{   .name="windows7light",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .contrast=20,
++    .filter_params={on, 20, 25, 38, 25, 05},
++    .fringe_filter_strength=100,
++    .gamma_correction={1000, 160},
++    .stem_snapping_sliding_scale=30,
++    .use_known_settings_on_selected_fonts=true,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=100
++},
++#line 226 "ftinf_sh.gperf"
++{   .name="windowsxplight",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .brightness=20,
++    .contrast=30,
++    .filter_params={on, 6, 25, 44, 25, 6},
++    .fringe_filter_strength=100,
++    .gamma_correction={1000, 120},
++    .stem_alignment_strength=15,
++    .stem_fitting_strength=15,
++    .stem_snapping_sliding_scale=30,
++    .use_known_settings_on_selected_fonts=true,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=65
++},
++#line 64 "ftinf_sh.gperf"
++{   .name="nudge",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_increase_glyph_heights=true,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .filter_params={on, 11, 22, 38, 22, 11},
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=25,
++    .stem_fitting_strength=15,
++    .stem_snapping_sliding_scale=30,
++    .use_various_tweaks=true,
++},
++#line 144 "ftinf_sh.gperf"
++{   .name="ultimate2",
++    .filter_params={on, 6, 22, 36, 22, 6},
++    .fringe_filter_strength=25,
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=15,
++    .stem_fitting_strength=15,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=25
++},
++#line 197 "ftinf_sh.gperf"
++{   .name="windows7",
++    .filter_params={on, 20, 25, 42, 25, 06},
++    .fringe_filter_strength=100,
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_vertical_stem_darken_strength=25,
++    .windows_style_sharpening_strength=65,
++    .gamma_correction={1000, 120},
++    .brightness=10,
++    .contrast=20,
++    .use_various_tweaks=true,
++    .autohint_snap_stem_height=100,
++    .use_known_settings_on_selected_fonts=true,
++},
++#line 210 "ftinf_sh.gperf"
++{   .name="windowsxp",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .brightness=10,
++    .contrast=20,
++    .filter_params={on, 6, 25, 44, 25, 6},
++    .fringe_filter_strength=100,
++    .gamma_correction={1000, 120},
++    .stem_alignment_strength=15,
++    .stem_fitting_strength=15,
++    .stem_snapping_sliding_scale=30,
++    .use_known_settings_on_selected_fonts=true,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=65
++},
++#line 56 "ftinf_sh.gperf"
++{   .name="linux",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .filter_params={on, 6, 25, 44, 25, 6},
++    .gamma_correction={0, 100},
++    .use_various_tweaks=true
++},
++#line 135 "ftinf_sh.gperf"
++{   .name="ultimate1",
++    .filter_params={on, 4, 22, 38, 22, 4},
++    .fringe_filter_strength=25,
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=15,
++    .stem_fitting_strength=15,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=25
++},
++#line 87 "ftinf_sh.gperf"
++{   .name="push",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_increase_glyph_heights=true,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .filter_params={on, 11, 22, 38, 22, 11},
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=75,
++    .stem_fitting_strength=50,
++    .stem_snapping_sliding_scale=30,
++    .use_known_settings_on_selected_fonts=true,
++    .use_various_tweaks=true
++},
++#line 171 "ftinf_sh.gperf"
++{   .name="ultimate5",
++    .filter_params={on, 12, 28, 42, 28, 12},
++    .fringe_filter_strength=25,
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=15,
++    .stem_fitting_strength=15,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=25
++},
++#line 162 "ftinf_sh.gperf"
++{   .name="ultimate4",
++    .filter_params={on, 10, 25, 37, 25, 10},
++    .fringe_filter_strength=25,
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=15,
++    .stem_fitting_strength=15,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=25
++},
++#line 153 "ftinf_sh.gperf"
++{   .name="ultimate3",
++    .filter_params={on, 8, 24, 36, 24, 8},
++    .fringe_filter_strength=25,
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=15,
++    .stem_fitting_strength=15,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=25
++}
++    };
++
++  if (len <= MAX_WORD_LENGTH && len >= MIN_WORD_LENGTH)
++    {
++      register int key = _settings_hash (str, len);
++
++      if (key <= MAX_HASH_VALUE && key >= MIN_HASH_VALUE)
++        {
++          register const struct ftinf_s *resword;
++
++          switch (key - 3)
++            {
++              case 0:
++                resword = &wordlist[0];
++                goto compare;
++              case 1:
++                resword = &wordlist[1];
++                goto compare;
++              case 2:
++                resword = &wordlist[2];
++                goto compare;
++              case 3:
++                resword = &wordlist[3];
++                goto compare;
++              case 4:
++                resword = &wordlist[4];
++                goto compare;
++              case 5:
++                resword = &wordlist[5];
++                goto compare;
++              case 6:
++                resword = &wordlist[6];
++                goto compare;
++              case 7:
++                resword = &wordlist[7];
++                goto compare;
++              case 8:
++                resword = &wordlist[8];
++                goto compare;
++              case 9:
++                resword = &wordlist[9];
++                goto compare;
++              case 10:
++                resword = &wordlist[10];
++                goto compare;
++              case 11:
++                resword = &wordlist[11];
++                goto compare;
++              case 12:
++                resword = &wordlist[12];
++                goto compare;
++              case 14:
++                resword = &wordlist[13];
++                goto compare;
++              case 15:
++                resword = &wordlist[14];
++                goto compare;
++              case 16:
++                resword = &wordlist[15];
++                goto compare;
++              case 17:
++                resword = &wordlist[16];
++                goto compare;
++              case 19:
++                resword = &wordlist[17];
++                goto compare;
++              case 21:
++                resword = &wordlist[18];
++                goto compare;
++              case 26:
++                resword = &wordlist[19];
++                goto compare;
++              case 31:
++                resword = &wordlist[20];
++                goto compare;
++              case 36:
++                resword = &wordlist[21];
++                goto compare;
++            }
++          return 0;
++        compare:
++          {
++            register const char *s = resword->name;
++
++            if (*str == *s && !strcmp (str + 1, s + 1))
++              return resword;
++          }
++        }
++    }
++  return 0;
++}
++#line 242 "ftinf_sh.gperf"
++
++
++static const ftinf_t*
++ftinf_settings( const char *name ){
++    if( name ){
++        enum {
++            max_wlen=31
++        };
++        char buf[max_wlen+1];
++        int len=strlen( name );
++        if( len <= max_wlen ){
++            int i;
++            for( i=0; i<len; ++i )
++                buf[i]=tolower( name[i] );
++            buf[len]='\0';
++            return _settings_get( buf, len );
++        }
++    }
++    return NULL;
++}
++/*
++   gperf --output-file=ftinf_sh.c ftinf_sh.gperf
++*/
+diff --git a/src/base/ftinf_sh.gperf b/src/base/ftinf_sh.gperf
+new file mode 100644
+index 0000000..5f6e0ae
+--- /dev/null
++++ b/src/base/ftinf_sh.gperf
+@@ -0,0 +1,264 @@
++%struct-type
++%define slot-name name
++%enum
++%switch=1
++%readonly-tables
++%omit-struct-type
++%define lookup-function-name   _settings_get
++%define hash-function-name _settings_hash
++%{
++#include <ctype.h>
++static const struct ftinf_s* _settings_get( const char*str, unsigned len);
++%}
++struct ftinf_s;
++%%
++{   .name="custom",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .filter_params={on, 8, 24, 48, 24, 8},
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=75,
++    .stem_fitting_strength=50,
++    .stem_snapping_sliding_scale=30,
++    .use_known_settings_on_selected_fonts=true,
++    .use_various_tweaks=true
++},
++{   .name="classic",
++    .autohint_increase_glyph_heights=true,
++    .autohint_snap_stem_height=100,
++    .filter_params={on, 6, 25, 38, 25, 6},
++    .gamma_correction={0, 100},
++    .use_various_tweaks=true
++},
++{   .name="disabled",
++    .gamma_correction={0, 100},
++},
++{   .name="ipad",
++    .filter_params={on, 0, 0, 100, 0, 0},
++    .gamma_correction={1000, 80},
++    .grayscale_filter_strength=100
++},
++{   .name="infinality",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_increase_glyph_heights=true,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .filter_params={on, 11, 22, 38, 22, 11},
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=25,
++    .stem_fitting_strength=25,
++    .stem_snapping_sliding_scale=40,
++    .use_known_settings_on_selected_fonts=true,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=5
++},
++{   .name="linux",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .filter_params={on, 6, 25, 44, 25, 6},
++    .gamma_correction={0, 100},
++    .use_various_tweaks=true
++},
++{   .name="nudge",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_increase_glyph_heights=true,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .filter_params={on, 11, 22, 38, 22, 11},
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=25,
++    .stem_fitting_strength=15,
++    .stem_snapping_sliding_scale=30,
++    .use_various_tweaks=true,
++},
++{   .name="osx",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_vertical_stem_darken_strength=25,
++    .bold_embolden_x_value=16,
++    .brightness=10,
++    .contrast=20,
++    .filter_params={on, 3, 32, 38, 32, 3},
++    .gamma_correction={1000, 80},
++    .global_embolden_y_value=8,
++    .grayscale_filter_strength=25,
++},
++{   .name="push",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_increase_glyph_heights=true,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .filter_params={on, 11, 22, 38, 22, 11},
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=75,
++    .stem_fitting_strength=50,
++    .stem_snapping_sliding_scale=30,
++    .use_known_settings_on_selected_fonts=true,
++    .use_various_tweaks=true
++},
++{   .name="sharpened",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_increase_glyph_heights=true,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .filter_params={on, 11, 22, 38, 22, 11},
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=25,
++    .stem_fitting_strength=25,
++    .stem_snapping_sliding_scale=40,
++    .use_known_settings_on_selected_fonts=true,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=65
++},
++{   .name="shove",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_increase_glyph_heights=true,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .filter_params={on, 11, 22, 38, 22, 11},
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=100,
++    .stem_fitting_strength=100,
++    .use_known_settings_on_selected_fonts=true,
++    .use_various_tweaks=true
++},
++{   .name="ubuntu",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_vertical_stem_darken_strength=25,
++    .brightness=-10,
++    .contrast=15,
++    .filter_params={on, 11, 22, 38, 22, 11},
++    .gamma_correction={1000, 80},
++    .use_various_tweaks=true
++},
++{   .name="ultimate1",
++    .filter_params={on, 4, 22, 38, 22, 4},
++    .fringe_filter_strength=25,
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=15,
++    .stem_fitting_strength=15,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=25
++},
++{   .name="ultimate2",
++    .filter_params={on, 6, 22, 36, 22, 6},
++    .fringe_filter_strength=25,
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=15,
++    .stem_fitting_strength=15,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=25
++},
++{   .name="ultimate3",
++    .filter_params={on, 8, 24, 36, 24, 8},
++    .fringe_filter_strength=25,
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=15,
++    .stem_fitting_strength=15,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=25
++},
++{   .name="ultimate4",
++    .filter_params={on, 10, 25, 37, 25, 10},
++    .fringe_filter_strength=25,
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=15,
++    .stem_fitting_strength=15,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=25
++},
++{   .name="ultimate5",
++    .filter_params={on, 12, 28, 42, 28, 12},
++    .fringe_filter_strength=25,
++    .gamma_correction={0, 100},
++    .stem_alignment_strength=15,
++    .stem_fitting_strength=15,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=25
++},
++{   .name="vanilla",
++    .filter_params={on, 6, 25, 38, 25, 6},
++    .gamma_correction={0, 100},
++},
++{   .name="windows7light",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .contrast=20,
++    .filter_params={on, 20, 25, 38, 25, 05},
++    .fringe_filter_strength=100,
++    .gamma_correction={1000, 160},
++    .stem_snapping_sliding_scale=30,
++    .use_known_settings_on_selected_fonts=true,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=100
++},
++{   .name="windows7",
++    .filter_params={on, 20, 25, 42, 25, 06},
++    .fringe_filter_strength=100,
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_vertical_stem_darken_strength=25,
++    .windows_style_sharpening_strength=65,
++    .gamma_correction={1000, 120},
++    .brightness=10,
++    .contrast=20,
++    .use_various_tweaks=true,
++    .autohint_snap_stem_height=100,
++    .use_known_settings_on_selected_fonts=true,
++},
++{   .name="windowsxp",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .brightness=10,
++    .contrast=20,
++    .filter_params={on, 6, 25, 44, 25, 6},
++    .fringe_filter_strength=100,
++    .gamma_correction={1000, 120},
++    .stem_alignment_strength=15,
++    .stem_fitting_strength=15,
++    .stem_snapping_sliding_scale=30,
++    .use_known_settings_on_selected_fonts=true,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=65
++},
++{   .name="windowsxplight",
++    .autohint_horizontal_stem_darken_strength=10,
++    .autohint_snap_stem_height=100,
++    .autohint_vertical_stem_darken_strength=25,
++    .brightness=20,
++    .contrast=30,
++    .filter_params={on, 6, 25, 44, 25, 6},
++    .fringe_filter_strength=100,
++    .gamma_correction={1000, 120},
++    .stem_alignment_strength=15,
++    .stem_fitting_strength=15,
++    .stem_snapping_sliding_scale=30,
++    .use_known_settings_on_selected_fonts=true,
++    .use_various_tweaks=true,
++    .windows_style_sharpening_strength=65
++},
++%%
++
++static const ftinf_t*
++ftinf_settings( const char *name ){
++    if( name ){
++        enum {
++            max_wlen=31
++        };
++        char buf[max_wlen+1];
++        int len=strlen( name );
++        if( len <= max_wlen ){
++            int i;
++            for( i=0; i<len; ++i )
++                buf[i]=tolower( name[i] );
++            buf[len]='\0';
++            return _settings_get( buf, len );
++        }
++    }
++    return NULL;
++}
++/*
++   gperf --output-file=ftinf_sh.c ftinf_sh.gperf
++*/
 diff --git a/src/base/ftinit.c b/src/base/ftinit.c
 index b3b08fa..c125db9 100644
 --- a/src/base/ftinit.c
@@ -501,7 +2614,7 @@ index b3b08fa..c125db9 100644
      return error;
    }
 diff --git a/src/base/ftlcdfil.c b/src/base/ftlcdfil.c
-index 611b39f..0e7048c 100644
+index 611b39f..f59793a 100644
 --- a/src/base/ftlcdfil.c
 +++ b/src/base/ftlcdfil.c
 @@ -22,7 +22,10 @@
@@ -516,7 +2629,7 @@ index 611b39f..0e7048c 100644
  
  #ifdef FT_CONFIG_OPTION_SUBPIXEL_RENDERING
  
-@@ -306,11 +309,36 @@
+@@ -306,11 +309,37 @@
    FT_Library_SetLcdFilter( FT_Library    library,
                             FT_LcdFilter  filter )
    {
@@ -524,10 +2637,10 @@ index 611b39f..0e7048c 100644
 -                   { 0x08, 0x4d, 0x56, 0x4d, 0x08 };
      static const FT_LcdFiveTapFilter  light_weights =
                     { 0x00, 0x55, 0x56, 0x55, 0x00 };
--
+ 
 +#ifndef FT_CONFIG_OPTION_INFINALITY_PATCHSET
 +    static const FT_LcdFiveTapFilter  default_weights =
-+                            { 0x08, 0x4d, 0x56, 0x4d, 0x08 };
++                   { 0x08, 0x4d, 0x56, 0x4d, 0x08 };
 +#else
 +    FT_LcdFiveTapFilter default_weights;
 +    if( ftinf && ftinf->filter_params[0] )
@@ -799,7 +2912,7 @@ index 6161393..8c00aa9 100644
      driver->darken_params[0] = CFF_CONFIG_OPTION_DARKENING_PARAMETER_X1;
      driver->darken_params[1] = CFF_CONFIG_OPTION_DARKENING_PARAMETER_Y1;
 diff --git a/src/smooth/ftsmooth.c b/src/smooth/ftsmooth.c
-index 435854e..5d79844 100644
+index 435854e..d14cd1a 100644
 --- a/src/smooth/ftsmooth.c
 +++ b/src/smooth/ftsmooth.c
 @@ -26,6 +26,18 @@
@@ -1039,7 +3152,7 @@ index 435854e..5d79844 100644
 +    FT_Bitmap new_bitmap;
 +
 +
-+    FT_Bitmap_New( &new_bitmap );
++    FT_Bitmap_Init( &new_bitmap );
 +    FT_Bitmap_Copy( library, bitmap, &new_bitmap );
 +    new_line = (&new_bitmap)->buffer;
 +
@@ -1217,7 +3330,7 @@ index 435854e..5d79844 100644
 +    int       factor1, factor2;
 +    int       bias = 0;
 +
-+    FT_Bitmap_New( &new_bitmap );
++    FT_Bitmap_Init( &new_bitmap );
 +
 +    FT_Bitmap_Copy( library, bitmap, &new_bitmap );
 +    new_line = (&new_bitmap)->buffer;
@@ -1291,7 +3404,7 @@ index 435854e..5d79844 100644
 +    FT_Bitmap   new_bitmap;
 +
 +
-+    FT_Bitmap_New( &new_bitmap );
++    FT_Bitmap_Init( &new_bitmap );
 +    FT_Bitmap_Copy( library, bitmap, &new_bitmap );
 +    new_line = (&new_bitmap)->buffer;
 +
@@ -1333,7 +3446,7 @@ index 435854e..5d79844 100644
 +    FT_Bitmap new_bitmap;
 +
 +
-+    FT_Bitmap_New( &new_bitmap );
++    FT_Bitmap_Init( &new_bitmap );
 +    FT_Bitmap_Copy( library, bitmap, &new_bitmap );
 +    new_line = (&new_bitmap)->buffer;
 +
@@ -1382,7 +3495,7 @@ index 435854e..5d79844 100644
 +    FT_UInt   xx;
 +
 +
-+    FT_Bitmap_New(&new_bitmap);
++    FT_Bitmap_Init(&new_bitmap);
 +    FT_Bitmap_Copy(library, bitmap, &new_bitmap);
 +    new_line = (&new_bitmap)->buffer;
 +
@@ -1453,7 +3566,7 @@ index 435854e..5d79844 100644
 +    FT_Bitmap   new_bitmap;
 +
 +
-+    FT_Bitmap_New(&new_bitmap);
++    FT_Bitmap_Init(&new_bitmap);
 +
 +    line = bitmap->buffer;
 +    FT_Bitmap_Copy( library, bitmap, &new_bitmap );
@@ -3195,7 +5308,7 @@ index 435854e..5d79844 100644
 +
 +    FT_Int       brightness_value = 0.0;
 +    FT_Int       contrast_value = 0.0;
-+ 
++
 +    FT_Int       snapping_sliding_scale_value = 0;
 +
 +    FT_Int       global_embolden_x_value = 0;
@@ -3483,7 +5596,7 @@ index 435854e..5d79844 100644
          x_left  -= lcd_extra >> 1;
          width   += 3 * lcd_extra;
          pitch    = FT_PAD_CEIL( width, 4 );
-@@ -243,24 +2712,17 @@
+@@ -243,23 +2712,16 @@
  
        if ( vmul )
        {
@@ -3506,12 +5619,11 @@ index 435854e..5d79844 100644
 -      goto Exit;
 +#ifdef FT_CONFIG_OPTION_INFINALITY_PATCHSET
      }
- 
 +#endif
 +
+ 
      /* Required check is (pitch * height < FT_ULONG_MAX),        */
      /* but we care realistic cases only.  Always pitch <= width. */
-     if ( width > 0x7FFF || height > 0x7FFF )
 @@ -271,6 +2733,22 @@
        goto Exit;
      }
@@ -3567,7 +5679,7 @@ index 435854e..5d79844 100644
      /* set up parameters */
      params.target = bitmap;
      params.source = outline;
-@@ -348,9 +2808,153 @@
+@@ -348,8 +2808,152 @@
      if ( error )
        goto Exit;
  
@@ -3692,7 +5804,7 @@ index 435854e..5d79844 100644
 +
 +
 +        if ( lcd_filter_func )
-+          lcd_filter_func( bitmap, mode, slot->library );
++          lcd_filter_func( bitmap, mode, lcd_weights );
 +
 +        if ( grayscale_filter_strength > 0 )
 +          _ft_lcd_grayscale_filter( bitmap,
@@ -3712,15 +5824,14 @@ index 435854e..5d79844 100644
 +    }
 +    else if ( mode == FT_RENDER_MODE_LCD     &&
 +              lcd_filter_func )
-+          lcd_filter_func( bitmap, mode, slot->library );
++          lcd_filter_func( bitmap, mode, lcd_weights );
 +#else
      if ( lcd_filter_func )
        lcd_filter_func( bitmap, mode, lcd_weights );
- 
 +#endif /* FT_CONFIG_OPTION_INFINALITY_PATCHSET */
+ 
  #else /* !FT_CONFIG_OPTION_SUBPIXEL_RENDERING */
  
-     /* render outline into bitmap */
 @@ -408,6 +3012,20 @@
  
  #endif /* !FT_CONFIG_OPTION_SUBPIXEL_RENDERING */

--- a/01_lib32-freetype2-iu/PKGBUILD
+++ b/01_lib32-freetype2-iu/PKGBUILD
@@ -5,9 +5,9 @@
 
 _pkgbasename=freetype2
 pkgname=lib32-$_pkgbasename-infinality-ultimate
-pkgver=2.7.1
-pkgrel=2
-_patchrel=2017.01.11
+pkgver=2.8
+pkgrel=1
+_patchrel=2017.05.24
 pkgdesc="TrueType font rendering library with Infinality patches and custom settings by bohoomil (32-bit, infinality-bundle)."
 arch=(x86_64)
 license=('GPL' 'MIT')
@@ -23,9 +23,9 @@ source=(http://downloads.sourceforge.net/sourceforge/freetype/freetype-${pkgver}
 	0001-Enable-table-validation-modules.patch
         0002-infinality-${pkgver}-${_patchrel}.patch)
 
-sha1sums=('4d08a9a6567c6332d58e9a5f9a7e9e3fbce66789'
+sha1sums=('42c6b1f733fe13a3eba135f5025b22cb68450f91'
           'b31882ef5e8447e761acee1c4a44c0630cd4d465'
-          '7a23342d5d56274ff8a05c67f64b96e85929f629')
+          '4b442f097eeae28516b43c659a3d7a679129052c')
 
 prepare() {
   cd "freetype-${pkgver}"


### PR DESCRIPTION
Update to #10/#11, adds the missing files pointed out by @SolarAquarion and the fixes suggested by @archfan.